### PR TITLE
Add scenario-checker and improve scenario handling

### DIFF
--- a/carla-simulation/docker-compose.scenario.yml
+++ b/carla-simulation/docker-compose.scenario.yml
@@ -41,7 +41,6 @@ services:
       - -ic
       - |
         set -e
-        # Reads MAP/CUSTOM_* and validates selectable scenarios before startup.
         python3 /scenario_checker.py validate-runtime /carla-simulation/scenarios
         SCENARIOS_DIR=/carla-simulation/scenarios
         if [ -n "$${CUSTOM_OPENDRIVE}" ]; then
@@ -65,7 +64,6 @@ services:
       - -ic
       - |
         set -e
-        # Reads SCENARIO_FILE/MAP/CUSTOM_* and validates before startup.
         python3 /scenario_checker.py validate-runtime "/$${SCENARIO_FILE}"
         exec python3 -u ../additional-files/scenario_runner.py \
           --host carla-server \

--- a/carla-simulation/docker-compose.scenario.yml
+++ b/carla-simulation/docker-compose.scenario.yml
@@ -14,29 +14,48 @@ services:
     stop_grace_period: 30s
     volumes:
       - ./config/carla-environment/set_environment.py:/set_environment.py:ro
+
+  carla-scenario-runner-ros-template:
+    profiles:
+      - donotuse
+    extends:
+      file: ./carla-services.yml
+      service: carla-scenario-runner-ros
+    environment:
+      MAP: ${MAP:-}
+      CUSTOM_OPENDRIVE: ${CUSTOM_OPENDRIVE:-}
+      CUSTOM_LANELET: ${CUSTOM_LANELET:-}
+    volumes:
+      - ../utils/scenario-checker/scenario_checker.py:/scenario_checker.py:ro
+      - ./scenarios:/carla-simulation/scenarios
+
   carla-scenario-runner-ros-manual-testing:
     profiles:
       - manual-testing
     extends:
-      file: ./carla-services.yml
-      service: carla-scenario-runner-ros
+      service: carla-scenario-runner-ros-template
     environment:
       SCENARIO_MAP: ${CUSTOM_OPENDRIVE:-${MAP:-}}
     command: 
       - /bin/bash
       - -ic
       - |
-        ros2 launch carla_ros_scenario_runner carla_ros_scenario_runner_with_selection.launch.py \
-          scenario_runner_path:=$${SCENARIO_RUNNER_ROOT}
-    volumes:
-      - ./scenarios:/scenarios
+        set -e
+        # Reads MAP/CUSTOM_* and validates selectable scenarios before startup.
+        python3 /scenario_checker.py validate-runtime /carla-simulation/scenarios
+        SCENARIOS_DIR=/carla-simulation/scenarios
+        if [ -n "$${CUSTOM_OPENDRIVE}" ]; then
+          SCENARIOS_DIR="$$(dirname "/$${CUSTOM_OPENDRIVE#/}")"
+        fi
+        exec ros2 launch carla_ros_scenario_runner carla_ros_scenario_runner_with_selection.launch.py \
+          scenario_runner_path:=$${SCENARIO_RUNNER_ROOT} \
+          scenarios_dir:=$${SCENARIOS_DIR}
 
   carla-scenario-runner-ros-automated-testing:
     profiles:
       - automated-testing
     extends:
-      file: ./carla-services.yml
-      service: carla-scenario-runner-ros
+      service: carla-scenario-runner-ros-template
     depends_on:
       - carla-ros-bridge
     environment:
@@ -45,11 +64,12 @@ services:
       - /bin/bash
       - -ic
       - |
-        python3 -u ../additional-files/scenario_runner.py \
+        set -e
+        # Reads SCENARIO_FILE/MAP/CUSTOM_* and validates before startup.
+        python3 /scenario_checker.py validate-runtime "/$${SCENARIO_FILE}"
+        exec python3 -u ../additional-files/scenario_runner.py \
           --host carla-server \
           --openscenario /$${SCENARIO_FILE} \
           --output \
           --rtFactor 1.0 \
           --waitForEgo
-    volumes:
-      - ./scenarios:/carla-simulation/scenarios

--- a/carla-simulation/scenarios/custom-imports/.gitignore
+++ b/carla-simulation/scenarios/custom-imports/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!README.md

--- a/carla-simulation/scenarios/custom-imports/README.md
+++ b/carla-simulation/scenarios/custom-imports/README.md
@@ -1,0 +1,5 @@
+# Custom scenario imports
+
+Scenario bundles created by `utils/scenario-checker/scenario_checker.py` are
+stored here. Each import uses a separate directory containing its normalized
+`.xosc` file and, for custom maps, the matching `.xodr` and `.osm` files.

--- a/carla-simulation/scenarios/scenario-generator/campus_following.xosc
+++ b/carla-simulation/scenarios/scenario-generator/campus_following.xosc
@@ -49,8 +49,6 @@
               </Position>
             </TeleportAction>
           </PrivateAction>
-        </Private>
-        <Private entityRef="ego_vehicle">
           <PrivateAction>
             <LongitudinalAction>
               <SpeedAction>
@@ -61,8 +59,6 @@
               </SpeedAction>
             </LongitudinalAction>
           </PrivateAction>
-        </Private>
-        <Private entityRef="ego_vehicle">
           <PrivateAction>
             <ControllerAction>
               <OverrideControllerValueAction>

--- a/carla-simulation/scenarios/scenario-generator/campus_intersecting_with_vehicle_from_left.xosc
+++ b/carla-simulation/scenarios/scenario-generator/campus_intersecting_with_vehicle_from_left.xosc
@@ -49,8 +49,6 @@
               </Position>
             </TeleportAction>
           </PrivateAction>
-        </Private>
-        <Private entityRef="ego_vehicle">
           <PrivateAction>
             <LongitudinalAction>
               <SpeedAction>
@@ -61,8 +59,6 @@
               </SpeedAction>
             </LongitudinalAction>
           </PrivateAction>
-        </Private>
-        <Private entityRef="ego_vehicle">
           <PrivateAction>
             <ControllerAction>
               <OverrideControllerValueAction>

--- a/carla-simulation/scenarios/scenario-generator/campus_merging_following_with_vehicle_from_right.xosc
+++ b/carla-simulation/scenarios/scenario-generator/campus_merging_following_with_vehicle_from_right.xosc
@@ -49,8 +49,6 @@
               </Position>
             </TeleportAction>
           </PrivateAction>
-        </Private>
-        <Private entityRef="ego_vehicle">
           <PrivateAction>
             <LongitudinalAction>
               <SpeedAction>
@@ -61,8 +59,6 @@
               </SpeedAction>
             </LongitudinalAction>
           </PrivateAction>
-        </Private>
-        <Private entityRef="ego_vehicle">
           <PrivateAction>
             <ControllerAction>
               <OverrideControllerValueAction>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,7 +30,7 @@ All variables below can be set through the Configuration GUI or manually in `.en
 | `ORIGIN_LAT` | GPS origin latitude for a custom lanelet map frame. Set together with `ORIGIN_LON` or leave both empty. | `50.782329` |
 | `ORIGIN_LON` | GPS origin longitude for a custom lanelet map frame. Set together with `ORIGIN_LAT` or leave both empty. | `6.070377` |
 | `LANELET_RELOAD` | `true` derives the Lanelet2 map from the simulation map; `false` uses `CUSTOM_LANELET`. Set automatically by the Configuration GUI. | `true`, `false` |
-| `SCENARIO_FILE` | *OpenSCENARIO* file executed directly using the CARLA scenario runner within the `automated-testing` profile. The Configuration GUI filters available scenarios for the selected map. For sequential runs of multiple scenarios, use the [multi-scenario execution script](./example-scenario-execution.md#execute-multiple-scenarios). | `carla-simulation/scenarios/scenario-generator/campus_following.xosc` |
+| `SCENARIO_FILE` | *OpenSCENARIO* file executed directly using the CARLA scenario runner within the `automated-testing` profile. The Configuration GUI filters available scenarios for the selected map and can validate/import custom scenario bundles. For sequential runs of multiple scenarios, use the [multi-scenario execution script](./example-scenario-execution.md#execute-multiple-scenarios). | `carla-simulation/scenarios/scenario-generator/campus_following.xosc` |
 | `USE_SIM_TIME` | Enables ROS simulated time across the stack. Must stay `true` in this setup. | `true` |
 | `ROS_TRACING` | Enables ROS 2 tracing for supported services. | `false`, `true` |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,8 +27,8 @@ All variables below can be set through the Configuration GUI or manually in `.en
 | `SPAWN_POINT` | Ego spawn point, given as `x,y,z,heading` in simulation map coordinates, or as `lat,lon,altitude,heading` when suffixed with `wgs84`. Required for prebuilt maps. | `50.787510,6.045938,260.0,90.0,wgs84`, `-1.0,-154.0,1.0,238.0` |
 | `CUSTOM_OPENDRIVE` | Custom *OpenDRIVE* (`.xodr`) map for CARLA standalone map mode. Not supported for SUMO. | `custom.xodr` |
 | `CUSTOM_LANELET` | Matching Lanelet2 `.osm` map for route planning and map server. Required with custom OpenDRIVE. | `custom.osm` |
-| `ORIGIN_LAT` | GPS origin latitude for a custom lanelet map frame. Set together with `ORIGIN_LON` or leave both empty. | `50.782329` |
-| `ORIGIN_LON` | GPS origin longitude for a custom lanelet map frame. Set together with `ORIGIN_LAT` or leave both empty. | `6.070377` |
+| `ORIGIN_LAT` | GPS origin latitude for a custom Lanelet2 map frame. Set together with `ORIGIN_LON` or leave both empty. | `50.782329` |
+| `ORIGIN_LON` | GPS origin longitude for a custom Lanelet2 map frame. Set together with `ORIGIN_LAT` or leave both empty. | `6.070377` |
 | `LANELET_RELOAD` | `true` derives the Lanelet2 map from the simulation map; `false` uses `CUSTOM_LANELET`. Set automatically by the Configuration GUI. | `true`, `false` |
 | `SCENARIO_FILE` | *OpenSCENARIO* file executed directly using the CARLA scenario runner within the `automated-testing` profile. The Configuration GUI filters available scenarios for the selected map and can validate/import custom scenario bundles. For sequential runs of multiple scenarios, use the [multi-scenario execution script](./example-scenario-execution.md#execute-multiple-scenarios). | `carla-simulation/scenarios/scenario-generator/campus_following.xosc` |
 | `USE_SIM_TIME` | Enables ROS simulated time across the stack. Must stay `true` in this setup. | `true` |

--- a/docs/example-scenario-execution.md
+++ b/docs/example-scenario-execution.md
@@ -42,6 +42,10 @@ The scenarios can be used as templates or replaced with compatible OpenSCENARIO 
 >
 > While the scenario generation tools above focus on individual scenarios, scenario.center covers the preceding steps of a scenario-based evaluation workflow. It derives scenario concepts from real-world traffic observations and supports scenario identification, analysis, comparison, and structured storage in a searchable database. Coverage, occurrence likelihood, and risk information help select relevant cases and build representative test catalogs. Compatible concrete OpenSCENARIO and OpenDRIVE files can then be incorporated into OpenADSim workflows.
 
+## Import and Validate Custom Scenarios
+
+Use **Import scenario** in the Configuration GUI to upload an `.xosc` file, plus `.xodr` and Lanelet2 `.osm` files for custom maps. **Validate and import** checks compatibility, adapts a copy for OpenADSim, and selects the imported scenario and map. In addition, all scenarios are also checked automatically before execution. For CLI usage and details, see the [scenario-checker documentation](../utils/scenario-checker/README.md).
+
 ## Manual Scenario Execution Using RViz
 
 Manual mode lets you select, start, and repeat scenarios through RViz. OpenADStack controls the `ego_vehicle`, while the CARLA scenario runner controls the other scenario participants.

--- a/docs/example-scenario-execution.md
+++ b/docs/example-scenario-execution.md
@@ -44,7 +44,7 @@ The scenarios can be used as templates or replaced with compatible OpenSCENARIO 
 
 ## Import and Validate Custom Scenarios
 
-Use **Import scenario** in the Configuration GUI to upload an `.xosc` file, plus `.xodr` and Lanelet2 `.osm` files for custom maps. **Validate and import** checks compatibility, adapts a copy for OpenADSim, and selects the imported scenario and map. In addition, all scenarios are also checked automatically before execution. For CLI usage and details, see the [scenario-checker documentation](../utils/scenario-checker/README.md).
+Use **Import scenario** in the Configuration GUI to upload an `.xosc` file, plus `.xodr` and Lanelet2 `.osm` files for custom maps. **Validate and import** checks compatibility, adapts a copy for OpenADSim, and selects the imported scenario and map. In addition, all scenarios are also checked automatically before execution. For CLI usage and details, see the [scenario-checker documentation](https://github.com/openads-project/openadsim/blob/main/utils/scenario-checker/README.md).
 
 ## Manual Scenario Execution Using RViz
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -160,7 +160,7 @@ Custom OpenDRIVE maps are supported when using the CARLA simulation backend.
 MAP=
 CUSTOM_OPENDRIVE=<path-to-custom-opendrive-map>.xodr
 SPAWN_POINT=
-CUSTOM_LANELET=<path-to-custom-lanelet-map>.osm
+CUSTOM_LANELET=<path-to-custom-lanelet2-map>.osm
 LANELET_RELOAD=false
 ```
 
@@ -174,7 +174,7 @@ For OpenADStack route planning on a custom map, also provide a matching Lanelet2
 docker compose up -d
 ```
 
-5. If the map or ego vehicle does not load, inspect the CARLA ROS bridge and lanelet map server logs:
+5. If the map or ego vehicle does not load, inspect the CARLA ROS bridge and Lanelet2 map server logs:
 
 ```bash
 docker compose logs -f carla-ros-bridge carla-spawn-objects localization.lanelet2-map-server

--- a/examples/scenario-execution/scenario-execution.py
+++ b/examples/scenario-execution/scenario-execution.py
@@ -742,7 +742,7 @@ class ScenarioExecutor:
             compose_log = ROOT_DIR / environment["DATA_DIRECTORY"] / "compose.log"
 
             LOGGER.info("%s Map: %s", scenario_label, map_selection.description)
-            LOGGER.info("%s Lanelet: %s", scenario_label, lanelet_description)
+            LOGGER.info("%s Lanelet2: %s", scenario_label, lanelet_description)
             LOGGER.info(
                 "%s Bag recording: %s",
                 scenario_label,
@@ -878,7 +878,7 @@ Configuration:
   MAP selects a prebuilt CARLA map. CUSTOM_OPENDRIVE selects an .xodr file.
   They override RoadNetwork/LogicFile and must not both be non-empty.
   CUSTOM_LANELET overrides automatic .osm detection. LANELET_RELOAD is
-  derived from the resolved Lanelet source. Use -b to record a ROS bag. The -o
+  derived from the resolved Lanelet2 source. Use -b to record a ROS bag. The -o
   option also enables bag recording and requires OP_OPENDRIVE for prebuilt
   CARLA maps.
 

--- a/examples/scenario-execution/scenario-execution.py
+++ b/examples/scenario-execution/scenario-execution.py
@@ -822,6 +822,7 @@ class ScenarioExecutor:
             return 1
         LOGGER.info("Discovered %s scenarios", len(scenarios))
 
+        failures: list[tuple[Path, str]] = []
         xhost_enabled = False
         try:
             run_command(
@@ -832,7 +833,15 @@ class ScenarioExecutor:
             )
             xhost_enabled = True
             for index, scenario_file in enumerate(scenarios, start=1):
-                self.run_scenario(scenario_file, index, len(scenarios))
+                try:
+                    self.run_scenario(scenario_file, index, len(scenarios))
+                except (subprocess.CalledProcessError, ScenarioExecutionError, OSError) as error:
+                    reason = str(error)
+                    failures.append((scenario_file, reason))
+                    LOGGER.error(
+                        "[%s/%s] %s Failed | %s",
+                        index, len(scenarios), repo_relative(scenario_file), reason,
+                    )
                 if index < len(scenarios) and self.args.wait_seconds != "0":
                     LOGGER.info(
                         "Waiting %s seconds before the next scenario",
@@ -848,7 +857,13 @@ class ScenarioExecutor:
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
                 )
-        return 0
+        LOGGER.info(
+            "Execution summary | total=%s | succeeded=%s | failed=%s",
+            len(scenarios), len(scenarios) - len(failures), len(failures),
+        )
+        for scenario_file, reason in failures:
+            LOGGER.error("Failed scenario: %s | %s", repo_relative(scenario_file), reason)
+        return 1 if failures else 0
 
 
 def parse_delay(value: str) -> str:

--- a/examples/scenario-execution/scenario-execution.py
+++ b/examples/scenario-execution/scenario-execution.py
@@ -23,6 +23,7 @@ DEFAULT_SCENARIO_FILTER = "*.xosc"
 DEFAULT_WAIT_SECONDS = "5"
 PROGRESS_INTERVAL_SECONDS = 10
 COMPOSE_COMMAND = ("docker", "compose", "--env-file", "/dev/null")
+SCENARIO_CHECKER = ROOT_DIR / "utils/scenario-checker/scenario_checker.py"
 ENV_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 DELAY_PATTERN = re.compile(r"^[0-9]+(?:[.][0-9]+)?$")
 
@@ -263,6 +264,65 @@ def run_command(
         raise ScenarioExecutionError(f"Command not found: {command[0]}") from error
 
 
+def validate_scenario_compatibility(
+    scenario_file: Path,
+    environment: dict[str, str],
+) -> None:
+    require_file(SCENARIO_CHECKER, "scenario checker")
+    command = [
+        sys.executable,
+        str(SCENARIO_CHECKER),
+        "validate",
+        str(scenario_file),
+        "--repo-root",
+        str(ROOT_DIR),
+        "--json",
+    ]
+    if environment.get("MAP"):
+        command.extend(["--expected-map", environment["MAP"]])
+    if environment.get("CUSTOM_OPENDRIVE"):
+        opendrive_path = str(resolve_path(environment["CUSTOM_OPENDRIVE"]))
+        command.extend(
+            [
+                "--opendrive",
+                opendrive_path,
+                "--expected-opendrive",
+                opendrive_path,
+            ]
+        )
+    if environment.get("CUSTOM_LANELET"):
+        lanelet_path = str(resolve_path(environment["CUSTOM_LANELET"]))
+        command.extend(
+            [
+                "--lanelet",
+                lanelet_path,
+                "--expected-lanelet",
+                lanelet_path,
+            ]
+        )
+
+    completed = run_command(
+        command,
+        os.environ.copy(),
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        payload = json.loads(completed.stdout or "{}")
+    except json.JSONDecodeError as error:
+        raise ScenarioExecutionError(
+            f"Scenario checker returned invalid output: {completed.stderr.strip()}"
+        ) from error
+    for warning in payload.get("warnings", []):
+        LOGGER.warning("Scenario validation: %s", warning)
+    if completed.returncode or not payload.get("valid"):
+        errors = payload.get("errors", [])
+        raise ScenarioExecutionError(
+            "Scenario validation failed: " + "; ".join(errors or ["unknown error"])
+        )
+
+
 class ScenarioExecutor:
     def __init__(self, args: argparse.Namespace, config_path: Path, config: Config):
         self.args = args
@@ -357,6 +417,7 @@ class ScenarioExecutor:
     ) -> MapSelection:
         configured_map = environment.get("MAP", "")
         configured_opendrive = environment.get("CUSTOM_OPENDRIVE", "")
+        logic_file = read_logic_file(scenario_file)
         if configured_map and configured_opendrive:
             raise ScenarioExecutionError(
                 f"MAP and CUSTOM_OPENDRIVE cannot both be non-empty for {scenario_file}."
@@ -365,6 +426,22 @@ class ScenarioExecutor:
         if configured_opendrive:
             opendrive = resolve_path(configured_opendrive)
             require_file(opendrive, "CUSTOM_OPENDRIVE file")
+            logic_reference = Path(logic_file.replace("\\", "/"))
+            if opendrive.parent != scenario_file.parent.resolve():
+                raise ScenarioExecutionError(
+                    "CUSTOM_OPENDRIVE must be in the same directory as the "
+                    f"OpenSCENARIO file: {opendrive}"
+                )
+            if (
+                logic_reference.is_absolute()
+                or logic_reference.parent != Path(".")
+                or logic_reference.name != opendrive.name
+            ):
+                raise ScenarioExecutionError(
+                    "LogicFile filepath must reference CUSTOM_OPENDRIVE in the same "
+                    "directory as the OpenSCENARIO file; expected only the filename "
+                    f"{opendrive.name!r}, got {logic_file!r}"
+                )
             environment["CUSTOM_OPENDRIVE"] = repo_relative(opendrive)
             environment["MAP"] = ""
             return MapSelection(
@@ -378,8 +455,13 @@ class ScenarioExecutor:
             environment["CUSTOM_OPENDRIVE"] = ""
             description = f"configured prebuilt CARLA map: {configured_map}"
         else:
-            logic_file = read_logic_file(scenario_file)
             if logic_file.lower().endswith(".xodr"):
+                logic_reference = Path(logic_file.replace("\\", "/"))
+                if logic_reference.is_absolute() or logic_reference.parent != Path("."):
+                    raise ScenarioExecutionError(
+                        "LogicFile must reference an OpenDRIVE filename in the same "
+                        f"directory as the OpenSCENARIO file, got {logic_file!r}"
+                    )
                 opendrive = resolve_path(logic_file, scenario_file.parent)
                 require_file(opendrive, "OpenDRIVE file referenced by the scenario")
                 environment["CUSTOM_OPENDRIVE"] = repo_relative(opendrive)
@@ -435,6 +517,11 @@ class ScenarioExecutor:
             )
 
         if lanelet_file:
+            if lanelet_file.parent != scenario_file.parent.resolve():
+                raise ScenarioExecutionError(
+                    "CUSTOM_LANELET must be in the same directory as the "
+                    f"OpenSCENARIO file: {lanelet_file}"
+                )
             environment["CUSTOM_LANELET"] = repo_relative(lanelet_file)
             environment["LANELET_RELOAD"] = "false"
             return (
@@ -645,11 +732,12 @@ class ScenarioExecutor:
             self.pulled_profile_sets.add(profile_set)
 
         try:
-            self.prepare_output(environment["SCENARIO_NAME"], environment)
             map_selection = self.resolve_map(scenario_file, environment)
             lanelet_description = self.resolve_lanelet(
                 scenario_file, map_selection, environment
             )
+            validate_scenario_compatibility(scenario_file, environment)
+            self.prepare_output(environment["SCENARIO_NAME"], environment)
             environment_file = self.save_environment(environment, snapshot_names)
             compose_log = ROOT_DIR / environment["DATA_DIRECTORY"] / "compose.log"
 

--- a/utils/gui/Dockerfile
+++ b/utils/gui/Dockerfile
@@ -8,6 +8,9 @@ RUN apt-get update \
     && useradd --create-home --shell /bin/sh openadsim \
     && rm -rf /var/lib/apt/lists/*
 
+# Suppress Chromium's placeholder EULA dialog (Debian bug #1145071).
+RUN python -c 'import json; from pathlib import Path; p = Path("/etc/chromium/master_preferences"); prefs = json.loads(p.read_text()) if p.exists() else {}; prefs.setdefault("distribution", {})["require_eula"] = False; p.write_text(json.dumps(prefs))'
+
 # Install Python dependencies. Streamlit 1.61.0 is incompatible with the
 # breaking GZipResponder signature introduced in Starlette 1.4.0.
 RUN pip install --no-cache-dir \

--- a/utils/gui/README.md
+++ b/utils/gui/README.md
@@ -7,6 +7,8 @@ It can:
 - load existing `.env` configurations and expose them as editable forms
 - apply presets such as `scenario-execution` and `cooperative-perception`
 - configure profiles, vehicle, sensors, map, scenario and additional options
+- validate and import OpenSCENARIO bundles with optional OpenDRIVE/Lanelet2 maps
+- keep scenario, OpenDRIVE and Lanelet dropdowns locked to one selected import bundle
 - validate configuration dependencies and show warnings/errors
 - automatically sync valid drafts back to `.env`
 - run `docker compose up -d` and stop/remove running containers

--- a/utils/gui/README.md
+++ b/utils/gui/README.md
@@ -8,7 +8,7 @@ It can:
 - apply presets such as `scenario-execution` and `cooperative-perception`
 - configure profiles, vehicle, sensors, map, scenario and additional options
 - validate and import OpenSCENARIO bundles with optional OpenDRIVE/Lanelet2 maps
-- keep scenario, OpenDRIVE and Lanelet dropdowns locked to one selected import bundle
+- keep scenario, OpenDRIVE and Lanelet2 dropdowns locked to one selected import bundle
 - validate configuration dependencies and show warnings/errors
 - automatically sync valid drafts back to `.env`
 - run `docker compose up -d` and stop/remove running containers

--- a/utils/gui/README.md
+++ b/utils/gui/README.md
@@ -8,7 +8,7 @@ It can:
 - apply presets such as `scenario-execution` and `cooperative-perception`
 - configure profiles, vehicle, sensors, map, scenario and additional options
 - validate and import OpenSCENARIO bundles with optional OpenDRIVE/Lanelet2 maps
-- show scenarios and Lanelet2 files from the selected OpenDRIVE file's directory, while keeping OpenDRIVE maps freely selectable
+- show scenarios and Lanelet2 files from the selected OpenDRIVE file's directory, additionally matching scenarios to their OpenDRIVE reference, while keeping OpenDRIVE maps freely selectable
 - validate configuration dependencies and show warnings/errors
 - automatically sync valid drafts back to `.env`
 - run `docker compose up -d` and stop/remove running containers

--- a/utils/gui/README.md
+++ b/utils/gui/README.md
@@ -8,7 +8,7 @@ It can:
 - apply presets such as `scenario-execution` and `cooperative-perception`
 - configure profiles, vehicle, sensors, map, scenario and additional options
 - validate and import OpenSCENARIO bundles with optional OpenDRIVE/Lanelet2 maps
-- keep scenario, OpenDRIVE and Lanelet2 dropdowns locked to one selected import bundle
+- show scenarios and Lanelet2 files from the selected OpenDRIVE file's directory, while keeping OpenDRIVE maps freely selectable
 - validate configuration dependencies and show warnings/errors
 - automatically sync valid drafts back to `.env`
 - run `docker compose up -d` and stop/remove running containers

--- a/utils/gui/checks.py
+++ b/utils/gui/checks.py
@@ -1,7 +1,9 @@
 """Domain dependency checks for simulation configuration."""
 
+import importlib.util
 from dataclasses import dataclass, field
 from pathlib import Path
+import sys
 from typing import Optional
 
 from models import (
@@ -42,6 +44,34 @@ class EnvValidationResult:
     warnings: list[str] = field(default_factory=list)
     config: Optional[SimulationConfig] = None
     raw_values: dict[str, str] = field(default_factory=dict)
+
+
+_SCENARIO_CHECKER_MODULE = None
+
+
+def _load_scenario_checker(repo_root: Path):
+    global _SCENARIO_CHECKER_MODULE
+    if _SCENARIO_CHECKER_MODULE is not None:
+        return _SCENARIO_CHECKER_MODULE
+    checker_path = repo_root / "utils/scenario-checker/scenario_checker.py"
+    if not checker_path.is_file():
+        return None
+    spec = importlib.util.spec_from_file_location(
+        "openadsim_scenario_checker",
+        checker_path,
+    )
+    if spec is None or spec.loader is None:
+        return None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    _SCENARIO_CHECKER_MODULE = module
+    return module
+
+
+def _repo_path(repo_root: Path, value: str) -> Path:
+    path = Path(value)
+    return path if path.is_absolute() else repo_root / path
 
 
 def _is_float(value: str) -> bool:
@@ -150,6 +180,59 @@ def validate_config(config: SimulationConfig, repo_root: Optional[Path] = None) 
                 )
             )
 
+        if repo_root is not None:
+            custom_opendrive = _repo_path(
+                repo_root,
+                config.map.custom_opendrive.strip(),
+            ).resolve()
+            custom_lanelet_value = config.map.custom_lanelet.strip()
+            custom_lanelet = (
+                _repo_path(repo_root, custom_lanelet_value).resolve()
+                if custom_lanelet_value
+                else None
+            )
+            if custom_opendrive.suffix.lower() != ".xodr":
+                result.errors.append(
+                    ValidationIssue(
+                        path="map.custom_opendrive",
+                        message="CUSTOM_OPENDRIVE must end in .xodr",
+                    )
+                )
+            if not custom_opendrive.is_file():
+                result.errors.append(
+                    ValidationIssue(
+                        path="map.custom_opendrive",
+                        message=f"CUSTOM_OPENDRIVE does not exist: {custom_opendrive}",
+                    )
+                )
+            if custom_lanelet is not None and not custom_lanelet.is_file():
+                result.errors.append(
+                    ValidationIssue(
+                        path="map.custom_lanelet",
+                        message=f"CUSTOM_LANELET does not exist: {custom_lanelet}",
+                    )
+                )
+            if custom_lanelet is not None and custom_lanelet.suffix.lower() != ".osm":
+                result.errors.append(
+                    ValidationIssue(
+                        path="map.custom_lanelet",
+                        message="CUSTOM_LANELET must end in .osm",
+                    )
+                )
+            if (
+                custom_lanelet is not None
+                and custom_opendrive.parent != custom_lanelet.parent
+            ):
+                result.errors.append(
+                    ValidationIssue(
+                        path="map.custom_lanelet",
+                        message=(
+                            "CUSTOM_OPENDRIVE and CUSTOM_LANELET must be in the "
+                            "same scenario directory"
+                        ),
+                    )
+                )
+
         if config.map.prebuilt_map is None and config.map.map_name.strip():
             result.errors.append(
                 ValidationIssue(
@@ -230,6 +313,61 @@ def validate_config(config: SimulationConfig, repo_root: Optional[Path] = None) 
                 level="warning",
             )
         )
+
+    if config.scenario.scenario_file.strip() and repo_root is not None:
+        scenario_file = _repo_path(repo_root, config.scenario.scenario_file.strip())
+        if not scenario_file.is_file():
+            result.errors.append(
+                ValidationIssue(
+                    path="scenario.scenario_file",
+                    message=f"SCENARIO_FILE does not exist: {scenario_file}",
+                )
+            )
+        else:
+            checker = _load_scenario_checker(repo_root)
+            if checker is not None:
+                custom_opendrive = config.map.custom_opendrive.strip()
+                custom_lanelet = config.map.custom_lanelet.strip()
+                scenario_report = checker.validate_scenario(
+                    scenario_file,
+                    repo_root=repo_root,
+                    opendrive=(
+                        _repo_path(repo_root, custom_opendrive)
+                        if custom_opendrive
+                        else None
+                    ),
+                    lanelet=(
+                        _repo_path(repo_root, custom_lanelet)
+                        if custom_opendrive and custom_lanelet
+                        else None
+                    ),
+                    expected_map=("" if custom_opendrive else config.map.export_map()),
+                    expected_opendrive=(
+                        _repo_path(repo_root, custom_opendrive)
+                        if custom_opendrive
+                        else None
+                    ),
+                    expected_lanelet=(
+                        _repo_path(repo_root, custom_lanelet)
+                        if custom_opendrive and custom_lanelet
+                        else None
+                    ),
+                )
+                for message in scenario_report.errors:
+                    result.errors.append(
+                        ValidationIssue(
+                            path="scenario.scenario_file",
+                            message=message,
+                        )
+                    )
+                for message in scenario_report.warnings:
+                    result.warnings.append(
+                        ValidationIssue(
+                            path="scenario.scenario_file",
+                            message=message,
+                            level="warning",
+                        )
+                    )
 
     # Additional options
     if sumo_selected and config.additional.perception_profile != PerceptionProfile.DISABLED:

--- a/utils/gui/docker-compose.yml
+++ b/utils/gui/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - 8501:8501
     volumes:
       - ${PWD}:${PWD}:ro
+      - ${PWD}/carla-simulation/scenarios/custom-imports:${PWD}/carla-simulation/scenarios/custom-imports:rw
       - ${PWD}/.env:/.env
       - /var/run/docker.sock:/var/run/docker.sock
       - /usr/bin/docker:/usr/bin/docker:ro

--- a/utils/gui/gui.py
+++ b/utils/gui/gui.py
@@ -2,7 +2,11 @@
 
 from pathlib import Path
 import html
+import json
 import os
+import subprocess
+import sys
+import tempfile
 from typing import Any, Optional
 
 import streamlit as st
@@ -540,7 +544,11 @@ def render_field(
 
     if field.control == "select":
         options = list(force_options if force_options is not None else field.options)
-        if current_widget_value not in options and current_widget_value not in (None, ""):
+        if (
+            not field.strict_options
+            and current_widget_value not in options
+            and current_widget_value not in (None, "")
+        ):
             options.insert(0, str(current_widget_value))
         if not options:
             return False
@@ -563,7 +571,11 @@ def render_field(
 
     elif field.control == "select_or_text":
         options = list(force_options if force_options is not None else field.options)
-        if current_widget_value not in options and current_widget_value not in (None, ""):
+        if (
+            not field.strict_options
+            and current_widget_value not in options
+            and current_widget_value not in (None, "")
+        ):
             options.insert(0, str(current_widget_value))
         if not options:
             options = [""]
@@ -587,7 +599,7 @@ def render_field(
 
         new_value = st.selectbox(
             **selectbox_kwargs,
-            accept_new_options=True,
+            accept_new_options=not field.strict_options,
         )
 
     elif field.control == "multiselect":
@@ -640,7 +652,7 @@ def render_field(
     if field.control == "multiselect":
         if list(current_widget_value) != list(new_value):
             try:
-                config.set_value(field.path, new_value)
+                config.set_value(field.path, new_value, repo_root=REPO_ROOT)
                 _commit_config_change(config, field.path)
                 return True
             except ValueError as exc:
@@ -649,7 +661,7 @@ def render_field(
 
     if new_value != current_widget_value:
         try:
-            config.set_value(field.path, new_value)
+            config.set_value(field.path, new_value, repo_root=REPO_ROOT)
             _commit_config_change(config, field.path)
             return True
         except ValueError as exc:
@@ -806,6 +818,165 @@ def _render_profile_field(config: SimulationConfig, field: UiField) -> bool:
     return render_field(config, field, label_icon=_profile_icon_svg(field.path))
 
 
+def _render_scenario_import(config: SimulationConfig):
+    import_result = st.session_state.pop("scenario_import_result", None)
+    if import_result:
+        st.success(f"Imported `{import_result['scenario_file']}`")
+        with st.expander("Applied scenario adjustments"):
+            for action in import_result.get("actions", []):
+                st.caption(f"- {action}")
+            for warning in import_result.get("warnings", []):
+                st.warning(warning)
+
+    with st.expander("Import scenario"):
+        st.caption(
+            "Upload an OpenSCENARIO file and optionally override its map with an "
+            "OpenDRIVE/Lanelet2 pair. If LogicFile references an .xodr, both map "
+            "files must be uploaded. Existing import names receive an index suffix."
+        )
+        revision = st.session_state.get("scenario_import_revision", 0)
+        with st.form(f"scenario_import_form::{revision}"):
+            import_name = st.text_input(
+                "Import name (optional)",
+                help="When empty, a UTC timestamp is used.",
+            )
+            scenario_upload = st.file_uploader(
+                "OpenSCENARIO (.xosc)",
+                type=["xosc"],
+            )
+            opendrive_upload = st.file_uploader(
+                "OpenDRIVE override (.xodr, optional)",
+                type=["xodr"],
+            )
+            lanelet_upload = st.file_uploader(
+                "Lanelet2 map (.osm, required for custom OpenDRIVE)",
+                type=["osm"],
+            )
+            stop_on_route = st.checkbox(
+                "Stop when ego route completes",
+                value=True,
+            )
+            timeout = st.number_input(
+                "Maximum duration [s]",
+                min_value=0.1,
+                value=60.0,
+                step=1.0,
+            )
+            driven_distance = st.number_input(
+                "Driven-distance criterion [m]",
+                min_value=0.1,
+                value=30.0,
+                step=1.0,
+            )
+            submitted = st.form_submit_button(
+                "Validate and import",
+                use_container_width=True,
+            )
+
+        if not submitted:
+            return
+        if scenario_upload is None:
+            st.error("Please upload an OpenSCENARIO (.xosc) file.")
+            return
+
+        checker = REPO_ROOT / "utils/scenario-checker/scenario_checker.py"
+        output_root = REPO_ROOT / "carla-simulation/scenarios/custom-imports"
+        if not checker.is_file():
+            st.error(f"Scenario checker not found: {checker}")
+            return
+
+        try:
+            with tempfile.TemporaryDirectory(prefix="openadsim-scenario-import-") as temporary:
+                temporary_root = Path(temporary)
+
+                def save_upload(upload) -> Optional[Path]:
+                    if upload is None:
+                        return None
+                    destination = temporary_root / Path(upload.name).name
+                    destination.write_bytes(upload.getvalue())
+                    return destination
+
+                scenario_path = save_upload(scenario_upload)
+                opendrive_path = save_upload(opendrive_upload)
+                lanelet_path = save_upload(lanelet_upload)
+                assert scenario_path is not None
+
+                command = [
+                    sys.executable,
+                    str(checker),
+                    "import",
+                    str(scenario_path),
+                    "--output-root",
+                    str(output_root),
+                    "--repo-root",
+                    str(REPO_ROOT),
+                    "--name",
+                    import_name,
+                    "--timeout",
+                    str(timeout),
+                    "--driven-distance",
+                    str(driven_distance),
+                    "--json",
+                ]
+                if opendrive_path:
+                    command.extend(["--opendrive", str(opendrive_path)])
+                if lanelet_path:
+                    command.extend(["--lanelet", str(lanelet_path)])
+                if not stop_on_route:
+                    command.append("--no-ego-route-stop")
+
+                completed = subprocess.run(
+                    command,
+                    cwd=REPO_ROOT,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                payload = json.loads(completed.stdout or "{}")
+        except (OSError, json.JSONDecodeError) as error:
+            st.error(f"Scenario import failed: {error}")
+            return
+
+        if completed.returncode or not payload.get("valid"):
+            errors = payload.get("errors", [])
+            st.error("Scenario import failed")
+            for error in errors or [completed.stderr.strip() or "Unknown error"]:
+                st.caption(f"- {error}")
+            return
+
+        map_data = payload["map"]
+        if map_data["type"] == "prebuilt":
+            config.set_value("map.prebuilt_map", map_data["map_name"])
+        else:
+            scenario_directory = Path(payload["scenario_file"]).parent
+
+            def imported_map_path(value: str) -> str:
+                path = Path(value)
+                if not path.is_absolute() and path.parent == Path("."):
+                    path = scenario_directory / path
+                return path.as_posix()
+
+            config.set_value("map.prebuilt_map", "")
+            config.set_value(
+                "map.custom_opendrive",
+                imported_map_path(map_data["opendrive"]),
+            )
+            config.set_value(
+                "map.custom_lanelet",
+                imported_map_path(map_data["lanelet"]),
+            )
+        config.set_value("scenario.scenario_file", payload["scenario_file"])
+
+        st.session_state.config = config
+        st.session_state.editable_config = config.normalized_copy()
+        st.session_state.force_current_configuration = True
+        st.session_state.scenario_import_result = payload
+        st.session_state.scenario_import_revision = revision + 1
+        _clear_field_widget_state()
+        _next_field_revision()
+        st.rerun()
+
+
 def _render_configuration_tab(config: SimulationConfig):
     config_changed = False
     sections = {section.title: section for section in config.get_ui_sections(REPO_ROOT)}
@@ -862,6 +1033,9 @@ def _render_configuration_tab(config: SimulationConfig):
             for field in scenario_section.fields:
                 changed = render_field(config, field) or changed
             config_changed = config_changed or changed
+
+            if scenario_enabled:
+                _render_scenario_import(config)
 
             if not scenario_enabled:
                 st.caption("Scenario file is only configurable for manual or automated testing.")

--- a/utils/gui/models.py
+++ b/utils/gui/models.py
@@ -12,10 +12,8 @@ from typing import Any, Callable, ClassVar, Optional
 from pydantic import BaseModel, Field
 from utils import (
     discover_files_with_suffix,
-    filter_files_by_import_bundle,
+    filter_files_by_directory,
     filter_xosc_files_by_map,
-    first_import_bundle,
-    import_bundle_directory,
 )
 
 
@@ -499,34 +497,6 @@ class SimulationConfig(BaseModel):
         if trigger_path in {"map.prebuilt_map", "map.custom_opendrive"}:
             self.map.apply_ui_constraints(trigger_path)
 
-        bundle_fields = {
-            "map.custom_opendrive": (self.map, "custom_opendrive"),
-            "map.custom_lanelet": (self.map, "custom_lanelet"),
-            "scenario.scenario_file": (self.scenario, "scenario_file"),
-        }
-        if trigger_path not in bundle_fields:
-            return
-        selected_model, selected_attribute = bundle_fields[trigger_path]
-        selected_value = str(getattr(selected_model, selected_attribute)).strip()
-        if not selected_value:
-            return
-        selected_bundle = import_bundle_directory(selected_value)
-        for path, (model, attribute) in bundle_fields.items():
-            if path == trigger_path:
-                continue
-            value = str(getattr(model, attribute)).strip()
-            if not value:
-                continue
-            value_bundle = import_bundle_directory(value)
-            if (
-                selected_bundle is not None
-                and value_bundle != selected_bundle
-            ) or (
-                selected_bundle is None
-                and value_bundle is not None
-            ):
-                setattr(model, attribute, "")
-
     def normalized_copy(self) -> "SimulationConfig":
         config = SimulationConfig(**self.model_dump())
         config.apply_defaults()
@@ -602,40 +572,23 @@ class SimulationConfig(BaseModel):
         self.apply_defaults()
         self.apply_ui_constraints(path)
 
-        bundle_fields = {
-            "map.custom_opendrive": (self.map, "custom_opendrive", ".xodr"),
-            "map.custom_lanelet": (self.map, "custom_lanelet", ".osm"),
-            "scenario.scenario_file": (self.scenario, "scenario_file", ".xosc"),
-        }
-        selected_bundle = (
-            import_bundle_directory(str(self.get_value(path)))
-            if path in bundle_fields
-            else None
-        )
-        if repo_root is not None and selected_bundle is not None:
-            bundle_directory = repo_root / selected_bundle
-            for model, attribute, suffix in bundle_fields.values():
-                matches = sorted(bundle_directory.glob(f"*{suffix}"))
-                selected_file = (
-                    matches[0].relative_to(repo_root).as_posix()
-                    if len(matches) == 1
-                    else ""
-                )
-                setattr(model, attribute, selected_file)
-            self.apply_defaults()
+        if repo_root is not None and path == "map.custom_opendrive":
+            opendrive = self.map.custom_opendrive.strip()
+            for model, attribute, suffix in (
+                (self.map, "custom_lanelet", ".osm"),
+                (self.scenario, "scenario_file", ".xosc"),
+            ):
+                options = filter_files_by_directory(
+                    repo_root, discover_files_with_suffix(repo_root, suffix), opendrive,
+                ) if opendrive else []
+                current = str(getattr(model, attribute)).strip()
+                if current not in options:
+                    setattr(model, attribute, options[0] if len(options) == 1 else "")
 
-        if (
-            repo_root is not None
-            and path in {"map.prebuilt_map", "map.custom_opendrive"}
-            and self.scenario.scenario_file.strip()
-        ):
-            scenario_map = self.map.custom_opendrive.strip() or self.map.export_map()
-            matching_scenarios = filter_xosc_files_by_map(
-                repo_root,
-                [self.scenario.scenario_file.strip()],
-                scenario_map,
-            )
-            if not matching_scenarios:
+        if repo_root is not None and path == "map.prebuilt_map":
+            if not filter_xosc_files_by_map(
+                repo_root, [self.scenario.scenario_file], self.map.export_map(),
+            ):
                 self.scenario.scenario_file = ""
 
     @staticmethod
@@ -935,70 +888,36 @@ class SimulationConfig(BaseModel):
         current_scenario = self.scenario.scenario_file.strip()
         current_lanelet = self.map.custom_lanelet.strip()
         current_opendrive = self.map.custom_opendrive.strip()
-        active_import_bundle = first_import_bundle(
-            current_opendrive,
-            current_lanelet,
-            current_scenario,
-        )
-        scenario_map = self.map.custom_opendrive.strip() or self.map.export_map()
         scenario_options = discover_files_with_suffix(repo_root, ".xosc")
         lanelet_options = discover_files_with_suffix(repo_root, ".osm")
         opendrive_options = discover_files_with_suffix(repo_root, ".xodr")
-        if active_import_bundle:
-            scenario_options = filter_files_by_import_bundle(
-                scenario_options,
-                active_import_bundle,
+        if current_opendrive:
+            scenario_options = filter_files_by_directory(
+                repo_root, scenario_options, current_opendrive,
             )
-            lanelet_options = filter_files_by_import_bundle(
-                lanelet_options,
-                active_import_bundle,
+            lanelet_options = filter_files_by_directory(
+                repo_root, lanelet_options, current_opendrive,
             )
-            opendrive_options = filter_files_by_import_bundle(
-                opendrive_options,
-                active_import_bundle,
-            )
-            if import_bundle_directory(current_opendrive) == active_import_bundle:
-                scenario_options = filter_xosc_files_by_map(
-                    repo_root,
-                    scenario_options,
-                    current_opendrive,
-                )
         else:
             scenario_options = filter_xosc_files_by_map(
-                repo_root,
-                scenario_options,
-                scenario_map,
+                repo_root, scenario_options, self.map.export_map(),
             )
+            if current_lanelet and current_lanelet not in lanelet_options:
+                lanelet_options = [current_lanelet] + lanelet_options
+            if (
+                current_scenario and current_scenario not in scenario_options
+                and not self.map.export_map()
+            ):
+                scenario_options = [current_scenario] + scenario_options
         sumo_selected = self.additional.simulation == SimulationProfile.SUMO
         scenario_enabled = (
             not sumo_selected
             and self.additional.testing_profile != TestingProfile.DISABLED
         )
-        if (
-            current_scenario
-            and current_scenario not in scenario_options
-            and not scenario_map.strip()
-            and not active_import_bundle
-        ):
-            scenario_options = [current_scenario] + scenario_options
-
-        if (
-            current_lanelet
-            and current_lanelet not in lanelet_options
-            and (
-                not active_import_bundle
-                or import_bundle_directory(current_lanelet) == active_import_bundle
-            )
-        ):
-            lanelet_options = [current_lanelet] + lanelet_options
 
         if (
             current_opendrive
             and current_opendrive not in opendrive_options
-            and (
-                not active_import_bundle
-                or import_bundle_directory(current_opendrive) == active_import_bundle
-            )
         ):
             opendrive_options = [current_opendrive] + opendrive_options
 
@@ -1014,13 +933,13 @@ class SimulationConfig(BaseModel):
             if sumo_selected
             else "Definition of a prebuilt or custom map."
         )
-        bundle_lock_description = (
-            f" Import bundle locked to {active_import_bundle}; scenario and map "
-            "dropdowns only show files from this directory."
-            if active_import_bundle
+        directory_filter_description = (
+            " Scenarios and Lanelet2 files are shown only from the OpenDRIVE file’s directory."
+            " You can select a different OpenDRIVE map at any time."
+            if current_opendrive
             else ""
         )
-        map_section_description += bundle_lock_description
+        map_section_description += directory_filter_description
         map_source_description = (
             "Choose a SUMO map. Available maps: campus."
             "CUSTOM_LANELET can still be used optionally."
@@ -1032,7 +951,7 @@ class SimulationConfig(BaseModel):
         )
         scenario_control = (
             "select_or_text"
-            if scenario_options or active_import_bundle
+            if scenario_options or current_opendrive
             else "text"
         )
         vehicle_options = (
@@ -1112,7 +1031,6 @@ class SimulationConfig(BaseModel):
                     control="select_or_text",
                     options=tuple(opendrive_select_options),
                     disabled=sumo_selected or self.map.prebuilt_map is not None,
-                    strict_options=bool(active_import_bundle),
                 ),
                 UiField(
                     path="map.custom_lanelet",
@@ -1124,7 +1042,7 @@ class SimulationConfig(BaseModel):
                     ),
                     control="select_or_text",
                     options=tuple(lanelet_select_options),
-                    strict_options=bool(active_import_bundle),
+                    strict_options=bool(current_opendrive),
                 ),
                 UiField(
                     path="map.origin_lat",
@@ -1157,7 +1075,7 @@ class SimulationConfig(BaseModel):
             title="Scenario",
             description=(
                 "Scenario file used for manual or automated testing."
-                + bundle_lock_description
+                + directory_filter_description
             ),
             fields=(
                 UiField(
@@ -1180,7 +1098,7 @@ class SimulationConfig(BaseModel):
                     options=tuple(scenario_select_options),
                     empty_option_label="No scenario selected",
                     disabled=not scenario_enabled,
-                    strict_options=bool(active_import_bundle),
+                    strict_options=bool(current_opendrive),
                 ),
             ),
         )

--- a/utils/gui/models.py
+++ b/utils/gui/models.py
@@ -12,7 +12,10 @@ from typing import Any, Callable, ClassVar, Optional
 from pydantic import BaseModel, Field
 from utils import (
     discover_files_with_suffix,
+    filter_files_by_import_bundle,
     filter_xosc_files_by_map,
+    first_import_bundle,
+    import_bundle_directory,
 )
 
 
@@ -140,6 +143,7 @@ class UiField:
     disabled: bool = False
     none_as_empty: bool = False
     empty_option_label: str = ""
+    strict_options: bool = False
 
 
 @dataclass(frozen=True)
@@ -495,6 +499,34 @@ class SimulationConfig(BaseModel):
         if trigger_path in {"map.prebuilt_map", "map.custom_opendrive"}:
             self.map.apply_ui_constraints(trigger_path)
 
+        bundle_fields = {
+            "map.custom_opendrive": (self.map, "custom_opendrive"),
+            "map.custom_lanelet": (self.map, "custom_lanelet"),
+            "scenario.scenario_file": (self.scenario, "scenario_file"),
+        }
+        if trigger_path not in bundle_fields:
+            return
+        selected_model, selected_attribute = bundle_fields[trigger_path]
+        selected_value = str(getattr(selected_model, selected_attribute)).strip()
+        if not selected_value:
+            return
+        selected_bundle = import_bundle_directory(selected_value)
+        for path, (model, attribute) in bundle_fields.items():
+            if path == trigger_path:
+                continue
+            value = str(getattr(model, attribute)).strip()
+            if not value:
+                continue
+            value_bundle = import_bundle_directory(value)
+            if (
+                selected_bundle is not None
+                and value_bundle != selected_bundle
+            ) or (
+                selected_bundle is None
+                and value_bundle is not None
+            ):
+                setattr(model, attribute, "")
+
     def normalized_copy(self) -> "SimulationConfig":
         config = SimulationConfig(**self.model_dump())
         config.apply_defaults()
@@ -547,7 +579,13 @@ class SimulationConfig(BaseModel):
 
         return value
 
-    def set_value(self, path: str, value: Any):
+    def set_value(
+        self,
+        path: str,
+        value: Any,
+        *,
+        repo_root: Optional[Path] = None,
+    ):
         parts = path.split(".")
         target: Any = self
         for part in parts[:-1]:
@@ -563,6 +601,42 @@ class SimulationConfig(BaseModel):
 
         self.apply_defaults()
         self.apply_ui_constraints(path)
+
+        bundle_fields = {
+            "map.custom_opendrive": (self.map, "custom_opendrive", ".xodr"),
+            "map.custom_lanelet": (self.map, "custom_lanelet", ".osm"),
+            "scenario.scenario_file": (self.scenario, "scenario_file", ".xosc"),
+        }
+        selected_bundle = (
+            import_bundle_directory(str(self.get_value(path)))
+            if path in bundle_fields
+            else None
+        )
+        if repo_root is not None and selected_bundle is not None:
+            bundle_directory = repo_root / selected_bundle
+            for model, attribute, suffix in bundle_fields.values():
+                matches = sorted(bundle_directory.glob(f"*{suffix}"))
+                selected_file = (
+                    matches[0].relative_to(repo_root).as_posix()
+                    if len(matches) == 1
+                    else ""
+                )
+                setattr(model, attribute, selected_file)
+            self.apply_defaults()
+
+        if (
+            repo_root is not None
+            and path in {"map.prebuilt_map", "map.custom_opendrive"}
+            and self.scenario.scenario_file.strip()
+        ):
+            scenario_map = self.map.custom_opendrive.strip() or self.map.export_map()
+            matching_scenarios = filter_xosc_files_by_map(
+                repo_root,
+                [self.scenario.scenario_file.strip()],
+                scenario_map,
+            )
+            if not matching_scenarios:
+                self.scenario.scenario_file = ""
 
     @staticmethod
     def _parse_bool(value: str, default: bool = False) -> bool:
@@ -858,30 +932,74 @@ class SimulationConfig(BaseModel):
             file.writelines(self.to_env_lines())
 
     def get_ui_sections(self, repo_root: Path) -> list[UiSection]:
+        current_scenario = self.scenario.scenario_file.strip()
+        current_lanelet = self.map.custom_lanelet.strip()
+        current_opendrive = self.map.custom_opendrive.strip()
+        active_import_bundle = first_import_bundle(
+            current_opendrive,
+            current_lanelet,
+            current_scenario,
+        )
         scenario_map = self.map.custom_opendrive.strip() or self.map.export_map()
         scenario_options = discover_files_with_suffix(repo_root, ".xosc")
-        scenario_options = filter_xosc_files_by_map(
-            repo_root,
-            scenario_options,
-            scenario_map,
-        )
         lanelet_options = discover_files_with_suffix(repo_root, ".osm")
         opendrive_options = discover_files_with_suffix(repo_root, ".xodr")
+        if active_import_bundle:
+            scenario_options = filter_files_by_import_bundle(
+                scenario_options,
+                active_import_bundle,
+            )
+            lanelet_options = filter_files_by_import_bundle(
+                lanelet_options,
+                active_import_bundle,
+            )
+            opendrive_options = filter_files_by_import_bundle(
+                opendrive_options,
+                active_import_bundle,
+            )
+            if import_bundle_directory(current_opendrive) == active_import_bundle:
+                scenario_options = filter_xosc_files_by_map(
+                    repo_root,
+                    scenario_options,
+                    current_opendrive,
+                )
+        else:
+            scenario_options = filter_xosc_files_by_map(
+                repo_root,
+                scenario_options,
+                scenario_map,
+            )
         sumo_selected = self.additional.simulation == SimulationProfile.SUMO
         scenario_enabled = (
             not sumo_selected
             and self.additional.testing_profile != TestingProfile.DISABLED
         )
-        current_scenario = self.scenario.scenario_file.strip()
-        if current_scenario and current_scenario not in scenario_options and not scenario_map.strip():
+        if (
+            current_scenario
+            and current_scenario not in scenario_options
+            and not scenario_map.strip()
+            and not active_import_bundle
+        ):
             scenario_options = [current_scenario] + scenario_options
 
-        current_lanelet = self.map.custom_lanelet.strip()
-        if current_lanelet and current_lanelet not in lanelet_options:
+        if (
+            current_lanelet
+            and current_lanelet not in lanelet_options
+            and (
+                not active_import_bundle
+                or import_bundle_directory(current_lanelet) == active_import_bundle
+            )
+        ):
             lanelet_options = [current_lanelet] + lanelet_options
 
-        current_opendrive = self.map.custom_opendrive.strip()
-        if current_opendrive and current_opendrive not in opendrive_options:
+        if (
+            current_opendrive
+            and current_opendrive not in opendrive_options
+            and (
+                not active_import_bundle
+                or import_bundle_directory(current_opendrive) == active_import_bundle
+            )
+        ):
             opendrive_options = [current_opendrive] + opendrive_options
 
         lanelet_select_options = [""] + lanelet_options
@@ -896,6 +1014,13 @@ class SimulationConfig(BaseModel):
             if sumo_selected
             else "Definition of a prebuilt or custom map."
         )
+        bundle_lock_description = (
+            f" Import bundle locked to {active_import_bundle}; scenario and map "
+            "dropdowns only show files from this directory."
+            if active_import_bundle
+            else ""
+        )
+        map_section_description += bundle_lock_description
         map_source_description = (
             "Choose a SUMO map. Available maps: campus."
             "CUSTOM_LANELET can still be used optionally."
@@ -905,7 +1030,11 @@ class SimulationConfig(BaseModel):
                 "CUSTOM_OPENDRIVE and CUSTOM_LANELET."
             )
         )
-        scenario_control = "select_or_text" if scenario_options else "text"
+        scenario_control = (
+            "select_or_text"
+            if scenario_options or active_import_bundle
+            else "text"
+        )
         vehicle_options = (
             (Vehicle.KARL.value,)
             if sumo_selected
@@ -978,19 +1107,24 @@ class SimulationConfig(BaseModel):
                     label="Custom OpenDRIVE File",
                     description=(
                         "Path to .xodr file. Requires map source 'Custom OpenDRIVE'; "
-                        "CUSTOM_LANELET is required."
+                        "CUSTOM_LANELET and matching scenarios must use the same directory."
                     ),
                     control="select_or_text",
                     options=tuple(opendrive_select_options),
                     disabled=sumo_selected or self.map.prebuilt_map is not None,
+                    strict_options=bool(active_import_bundle),
                 ),
                 UiField(
                     path="map.custom_lanelet",
                     env_name="CUSTOM_LANELET",
                     label="Custom Lanelet File",
-                    description="Optional for prebuilt maps; required for 'Custom OpenDRIVE'",
+                    description=(
+                        "Optional for prebuilt maps; required for 'Custom OpenDRIVE' "
+                        "and must share its scenario directory."
+                    ),
                     control="select_or_text",
                     options=tuple(lanelet_select_options),
+                    strict_options=bool(active_import_bundle),
                 ),
                 UiField(
                     path="map.origin_lat",
@@ -1021,7 +1155,10 @@ class SimulationConfig(BaseModel):
 
         scenario_section = UiSection(
             title="Scenario",
-            description="Scenario file used for manual or automated testing.",
+            description=(
+                "Scenario file used for manual or automated testing."
+                + bundle_lock_description
+            ),
             fields=(
                 UiField(
                     path="map.spawn_point",
@@ -1043,6 +1180,7 @@ class SimulationConfig(BaseModel):
                     options=tuple(scenario_select_options),
                     empty_option_label="No scenario selected",
                     disabled=not scenario_enabled,
+                    strict_options=bool(active_import_bundle),
                 ),
             ),
         )

--- a/utils/gui/models.py
+++ b/utils/gui/models.py
@@ -1117,7 +1117,7 @@ class SimulationConfig(BaseModel):
                 UiField(
                     path="map.custom_lanelet",
                     env_name="CUSTOM_LANELET",
-                    label="Custom Lanelet File",
+                    label="Custom Lanelet2 File",
                     description=(
                         "Optional for prebuilt maps; required for 'Custom OpenDRIVE' "
                         "and must share its scenario directory."
@@ -1145,8 +1145,8 @@ class SimulationConfig(BaseModel):
                 UiField(
                     path="map.effective_lanelet_reload",
                     env_name="LANELET_RELOAD",
-                    label="Lanelet Reload (derived)",
-                    description="Disabled when custom lanelet map is used.",
+                    label="Lanelet2 Reload (derived)",
+                    description="Disabled when custom Lanelet2 map is used.",
                     control="bool",
                     disabled=True,
                 ),

--- a/utils/gui/models.py
+++ b/utils/gui/models.py
@@ -581,6 +581,8 @@ class SimulationConfig(BaseModel):
                 options = filter_files_by_directory(
                     repo_root, discover_files_with_suffix(repo_root, suffix), opendrive,
                 ) if opendrive else []
+                if suffix == ".xosc" and opendrive:
+                    options = filter_xosc_files_by_map(repo_root, options, opendrive)
                 current = str(getattr(model, attribute)).strip()
                 if current not in options:
                     setattr(model, attribute, options[0] if len(options) == 1 else "")
@@ -892,7 +894,7 @@ class SimulationConfig(BaseModel):
         lanelet_options = discover_files_with_suffix(repo_root, ".osm")
         opendrive_options = discover_files_with_suffix(repo_root, ".xodr")
         if current_opendrive:
-            scenario_options = filter_files_by_directory(
+            scenario_options = filter_xosc_files_by_map(
                 repo_root, scenario_options, current_opendrive,
             )
             lanelet_options = filter_files_by_directory(

--- a/utils/gui/start.sh
+++ b/utils/gui/start.sh
@@ -54,8 +54,14 @@ else
     --app=http://127.0.0.1:8501 >/tmp/openadsim-browser.log 2>&1 &
   browser_pid="$!"
   sleep 2
-  if ! kill -0 "$browser_pid" >/dev/null 2>&1 && ! pgrep -x chromium >/dev/null 2>&1; then
+  if ! kill -0 "$browser_pid" >/dev/null 2>&1; then
     warn_no_x11 "chromium exited immediately. See /tmp/openadsim-browser.log in the container."
+  else
+    wait "$browser_pid" || true
+    echo "Chromium closed; stopping the GUI container."
+    kill "$streamlit_pid" 2>/dev/null || true
+    wait "$streamlit_pid" 2>/dev/null || true
+    exit 0
   fi
 fi
 

--- a/utils/gui/utils.py
+++ b/utils/gui/utils.py
@@ -7,6 +7,16 @@ import xml.etree.ElementTree as ET
 IMPORT_ROOT_PARTS = ("carla-simulation", "scenarios", "custom-imports")
 
 
+def filter_files_by_directory(
+    repo_root: Path, files: list[str], reference: str,
+) -> list[str]:
+    directory = (repo_root / reference.replace("\\", "/")).resolve().parent
+    return [
+        path for path in files
+        if (repo_root / path.replace("\\", "/")).resolve().parent == directory
+    ]
+
+
 def discover_files_with_suffix(
     repo_root: Path,
     suffixes: str | tuple[str, ...] | list[str],

--- a/utils/gui/utils.py
+++ b/utils/gui/utils.py
@@ -4,6 +4,9 @@ from pathlib import Path
 import xml.etree.ElementTree as ET
 
 
+IMPORT_ROOT_PARTS = ("carla-simulation", "scenarios", "custom-imports")
+
+
 def discover_files_with_suffix(
     repo_root: Path,
     suffixes: str | tuple[str, ...] | list[str],
@@ -44,6 +47,39 @@ def discover_files_with_suffix(
     return sorted(found)
 
 
+def import_bundle_directory(value: str) -> str | None:
+    normalized = value.strip().replace("\\", "/")
+    if not normalized:
+        return None
+    parts = Path(normalized).parts
+    for index in range(len(parts) - len(IMPORT_ROOT_PARTS)):
+        if tuple(parts[index : index + len(IMPORT_ROOT_PARTS)]) != IMPORT_ROOT_PARTS:
+            continue
+        bundle_index = index + len(IMPORT_ROOT_PARTS)
+        if bundle_index + 1 >= len(parts):
+            return None
+        bundle_name = parts[bundle_index]
+        if bundle_name in {"", ".", ".."}:
+            return None
+        return Path(*IMPORT_ROOT_PARTS, bundle_name).as_posix()
+    return None
+
+
+def first_import_bundle(*values: str) -> str | None:
+    return next(
+        (
+            bundle
+            for value in values
+            if (bundle := import_bundle_directory(value)) is not None
+        ),
+        None,
+    )
+
+
+def filter_files_by_import_bundle(files: list[str], bundle: str) -> list[str]:
+    return [path for path in files if import_bundle_directory(path) == bundle]
+
+
 def _normalized_map_reference(map_value: str) -> str:
     value = map_value.strip().replace("\\", "/")
     if not value:
@@ -56,7 +92,7 @@ def _normalized_map_reference(map_value: str) -> str:
     return value.lower()
 
 
-def _xosc_map_reference(xosc_file: Path) -> str:
+def _xosc_logic_file(xosc_file: Path) -> str:
     try:
         root = ET.parse(xosc_file).getroot()
     except (OSError, ET.ParseError):
@@ -64,7 +100,7 @@ def _xosc_map_reference(xosc_file: Path) -> str:
 
     for element in root.iter():
         if element.tag.rsplit("}", 1)[-1] == "LogicFile":
-            return _normalized_map_reference(element.attrib.get("filepath", ""))
+            return element.attrib.get("filepath", "").strip()
 
     return ""
 
@@ -74,6 +110,28 @@ def filter_xosc_files_by_map(
     xosc_files: list[str],
     map_value: str,
 ) -> list[str]:
+    map_path = Path(map_value.strip().replace("\\", "/"))
+    if map_path.suffix.lower() == ".xodr":
+        configured_opendrive = (
+            map_path.resolve()
+            if map_path.is_absolute()
+            else (repo_root / map_path).resolve()
+        )
+        matching_scenarios: list[str] = []
+        for xosc_file in xosc_files:
+            scenario = (repo_root / xosc_file).resolve()
+            logic_reference = Path(
+                _xosc_logic_file(scenario).replace("\\", "/")
+            )
+            if (
+                scenario.parent == configured_opendrive.parent
+                and not logic_reference.is_absolute()
+                and logic_reference.parent == Path(".")
+                and logic_reference.name == configured_opendrive.name
+            ):
+                matching_scenarios.append(xosc_file)
+        return matching_scenarios
+
     selected_map = _normalized_map_reference(map_value)
     if not selected_map:
         return xosc_files
@@ -81,7 +139,8 @@ def filter_xosc_files_by_map(
     return [
         xosc_file
         for xosc_file in xosc_files
-        if _xosc_map_reference(repo_root / xosc_file) == selected_map
+        if _normalized_map_reference(_xosc_logic_file(repo_root / xosc_file))
+        == selected_map
     ]
 
 

--- a/utils/scenario-checker/.gitignore
+++ b/utils/scenario-checker/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/utils/scenario-checker/README.md
+++ b/utils/scenario-checker/README.md
@@ -1,9 +1,28 @@
 # OpenADSim Scenario Checker
 
-Validate an existing OpenSCENARIO file without modifying it:
+This tool checks OpenSCENARIO files against OpenADS-specific requirements for
+use in OpenADSim with CARLA and ScenarioRunner. It is not a general-purpose
+OpenSCENARIO validator and does not establish full compliance with the
+OpenSCENARIO standard.
+
+The `validate`, `validate-folder`, and `validate-runtime` commands only check
+files; they do not modify them. The `import` command creates a new bundle under
+`--output-root` with a modified, normalized scenario copy, leaving the source
+files unchanged.
+
+Check an existing OpenSCENARIO file against these requirements without modifying it:
 
 ```bash
 python3 utils/scenario-checker/scenario_checker.py validate scenario.xosc
+```
+
+Custom maps must always be supplied explicitly with `--opendrive` and
+`--lanelet`, even when the files are next to the scenario and `LogicFile`
+references the `.xodr`. No map files are discovered automatically.
+
+```bash
+python3 utils/scenario-checker/scenario_checker.py validate scenario.xosc \
+  --opendrive map.xodr --lanelet map.osm
 ```
 
 Validate all scenarios for one active map, as used by manual scenario selection:
@@ -26,7 +45,7 @@ detects files and directories automatically. For custom maps, the configured
 `.xodr`, `.osm`, and every matching `.xosc` must be in the same directory. The
 `LogicFile` value must be the exact `.xodr` filename without a directory.
 
-Import and normalize a self-contained scenario bundle:
+Create a self-contained scenario bundle with a normalized scenario copy:
 
 ```bash
 python3 utils/scenario-checker/scenario_checker.py import scenario.xosc \
@@ -45,8 +64,10 @@ Every imported custom bundle stores the resulting `.xosc`, `.xodr`, and `.osm`
 files together in its import directory. Prebuilt CARLA maps need only the
 `.xosc` file.
 
-Imports normalize OpenSCENARIO 1.x files to the ScenarioRunner-supported 1.1
-format. This removes 1.2 `VariableDeclarations` and converts the changed Event
+During `import`, the output scenario copy is normalized from OpenSCENARIO 1.x
+to the ScenarioRunner-supported 1.1 format. The following changes apply only to
+that copy, not to the source file or any validation command.
+Normalization removes 1.2 `VariableDeclarations` and converts the changed Event
 priority and Cartesian-distance values. Actor-level `ObjectController` elements
 and all existing ego `ControllerAction` elements are replaced by exactly one ROS
 controller action; unused catalog locations are cleared. Other external

--- a/utils/scenario-checker/README.md
+++ b/utils/scenario-checker/README.md
@@ -1,0 +1,54 @@
+# OpenADSim Scenario Checker
+
+Validate an existing OpenSCENARIO file without modifying it:
+
+```bash
+python3 utils/scenario-checker/scenario_checker.py validate scenario.xosc
+```
+
+Validate all scenarios for one active map, as used by manual scenario selection:
+
+```bash
+python3 utils/scenario-checker/scenario_checker.py validate-folder \
+  carla-simulation/scenarios --expected-map campus
+```
+
+Runtime containers use one environment-aware call before starting ScenarioRunner:
+
+```bash
+python3 /scenario_checker.py validate-runtime /carla-simulation/scenarios/example.xosc
+```
+
+The command reads `MAP`, `CUSTOM_OPENDRIVE`, and `CUSTOM_LANELET` and resolves
+repository-relative map paths below the mounted scenario root. Folder-based
+manual testing uses `validate-runtime /carla-simulation/scenarios`. The checker
+detects files and directories automatically. For custom maps, the configured
+`.xodr`, `.osm`, and every matching `.xosc` must be in the same directory. The
+`LogicFile` value must be the exact `.xodr` filename without a directory.
+
+Import and normalize a self-contained scenario bundle:
+
+```bash
+python3 utils/scenario-checker/scenario_checker.py import scenario.xosc \
+  --output-root carla-simulation/scenarios/custom-imports \
+  --name my-scenario \
+  --opendrive map.xodr \
+  --lanelet map.osm
+```
+
+An uploaded OpenDRIVE file overrides `RoadNetwork/LogicFile`. Without an
+OpenDRIVE upload, `LogicFile` must reference a supported prebuilt CARLA map.
+Custom maps always require explicit OpenDRIVE and Lanelet2 uploads during
+import; files merely adjacent to the source upload are not selected implicitly.
+
+Every imported custom bundle stores the resulting `.xosc`, `.xodr`, and `.osm`
+files together in its import directory. Prebuilt CARLA maps need only the
+`.xosc` file.
+
+Imports normalize OpenSCENARIO 1.x files to the ScenarioRunner-supported 1.1
+format. This removes 1.2 `VariableDeclarations` and converts the changed Event
+priority and Cartesian-distance values. Actor-level `ObjectController` elements
+and all existing ego `ControllerAction` elements are replaced by exactly one ROS
+controller action; unused catalog locations are cleared. Other external
+`CatalogReference` elements are rejected because catalog files are not part of
+the self-contained three-file bundle. Unsupported major versions are rejected.

--- a/utils/scenario-checker/README.md
+++ b/utils/scenario-checker/README.md
@@ -73,3 +73,8 @@ and all existing ego `ControllerAction` elements are replaced by exactly one ROS
 controller action; unused catalog locations are cleared. Other external
 `CatalogReference` elements are rejected because catalog files are not part of
 the self-contained three-file bundle. Unsupported major versions are rejected.
+
+`import` replaces all existing ego controllers with exactly one
+`RosRouteController` (`ros_vehicle_control_route_action.py`) in `Storyboard/Init`.
+Controller actions shared with other actors must be split before import.
+Validation only checks this setup; it does not modify controllers.

--- a/utils/scenario-checker/scenario_checker.py
+++ b/utils/scenario-checker/scenario_checker.py
@@ -1,0 +1,1376 @@
+#!/usr/bin/env python3
+
+"""Validate and import OpenSCENARIO bundles for OpenADSim/CARLA."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+
+PREBUILT_MAPS = {
+    "aldenhoven": "aldenhoven",
+    "campus": "campus",
+    "town10hd_opt": "Town10HD_Opt",
+}
+CRITERIA = (
+    "criteria_RunningStopTest",
+    "criteria_RunningRedLightTest",
+    "criteria_CollisionTest",
+    "criteria_WrongLaneTest",
+    "criteria_OnSidewalkTest",
+    "criteria_DrivenDistanceTest",
+)
+ROS_CONTROLLER_MODULE = "ros_vehicle_control_route_action.py"
+
+
+class ScenarioCheckerError(RuntimeError):
+    """Raised for a user-facing validation or import error."""
+
+
+@dataclass(frozen=True)
+class MapResolution:
+    kind: str
+    logic_file: str
+    map_name: str = ""
+    opendrive: Optional[Path] = None
+    lanelet: Optional[Path] = None
+
+
+@dataclass
+class ScenarioReport:
+    scenario: Path
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    planned_changes: list[str] = field(default_factory=list)
+    map_resolution: Optional[MapResolution] = None
+    ego_actor: str = ""
+
+    @property
+    def is_valid(self) -> bool:
+        return not self.errors
+
+    def to_dict(self) -> dict[str, object]:
+        map_data: dict[str, object] = {}
+        if self.map_resolution:
+            map_data = {
+                "type": self.map_resolution.kind,
+                "logic_file": self.map_resolution.logic_file,
+                "map_name": self.map_resolution.map_name,
+                "opendrive": str(self.map_resolution.opendrive or ""),
+                "lanelet": str(self.map_resolution.lanelet or ""),
+            }
+        return {
+            "valid": self.is_valid,
+            "scenario": str(self.scenario),
+            "ego_actor": self.ego_actor,
+            "map": map_data,
+            "errors": self.errors,
+            "warnings": self.warnings,
+            "planned_changes": self.planned_changes,
+        }
+
+
+@dataclass(frozen=True)
+class ImportResult:
+    directory: Path
+    scenario_file: Path
+    map_resolution: MapResolution
+    actions: tuple[str, ...]
+    warnings: tuple[str, ...]
+    repo_root: Path
+
+    def _relative(self, path: Optional[Path]) -> str:
+        if path is None:
+            return ""
+        try:
+            return path.resolve().relative_to(self.repo_root.resolve()).as_posix()
+        except ValueError:
+            return str(path.resolve())
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "valid": True,
+            "directory": self._relative(self.directory),
+            "scenario_file": self._relative(self.scenario_file),
+            "map": {
+                "type": self.map_resolution.kind,
+                "map_name": self.map_resolution.map_name,
+                "opendrive": self._relative(self.map_resolution.opendrive),
+                "lanelet": self._relative(self.map_resolution.lanelet),
+            },
+            "actions": list(self.actions),
+            "warnings": list(self.warnings),
+        }
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def _namespace(element: ET.Element) -> str:
+    if element.tag.startswith("{"):
+        return element.tag.split("}", 1)[0] + "}"
+    return ""
+
+
+def _child(parent: Optional[ET.Element], name: str) -> Optional[ET.Element]:
+    if parent is None:
+        return None
+    return next(
+        (element for element in list(parent) if _local_name(element.tag) == name),
+        None,
+    )
+
+
+def _children(parent: Optional[ET.Element], name: str) -> list[ET.Element]:
+    if parent is None:
+        return []
+    return [element for element in list(parent) if _local_name(element.tag) == name]
+
+
+def _path(parent: Optional[ET.Element], *names: str) -> Optional[ET.Element]:
+    element = parent
+    for name in names:
+        element = _child(element, name)
+        if element is None:
+            return None
+    return element
+
+
+def _iter(parent: Optional[ET.Element], name: str):
+    if parent is None:
+        return
+    for element in parent.iter():
+        if _local_name(element.tag) == name:
+            yield element
+
+
+def _subelement(
+    parent: ET.Element,
+    name: str,
+    attributes: Optional[dict[str, str]] = None,
+) -> ET.Element:
+    return ET.SubElement(
+        parent,
+        f"{_namespace(parent)}{name}",
+        attributes or {},
+    )
+
+
+def _normalize_map_reference(value: str) -> str:
+    normalized = value.strip().replace("\\", "/").rstrip("/")
+    filename = normalized.rsplit("/", 1)[-1]
+    if filename.lower().endswith(".xodr"):
+        filename = filename[:-5]
+    return filename.lower()
+
+
+def _canonical_prebuilt_map(value: str) -> str:
+    return PREBUILT_MAPS.get(_normalize_map_reference(value), "")
+
+
+def _version_conversion_issues(root: ET.Element) -> list[str]:
+    issues: list[str] = []
+    header = _child(root, "FileHeader")
+    if header is None:
+        return ["FileHeader is missing"]
+
+    major = header.get("revMajor", "")
+    minor = header.get("revMinor", "")
+    if major != "1":
+        return [f"Unsupported OpenSCENARIO major version {major or '<missing>'}; expected 1"]
+    if minor != "1":
+        issues.append(f"Convert OpenSCENARIO {major}.{minor or '<missing>'} to 1.1")
+    if _child(root, "VariableDeclarations") is not None:
+        issues.append("Remove OpenSCENARIO 1.2 VariableDeclarations")
+    if any(event.get("priority") == "override" for event in _iter(root, "Event")):
+        issues.append("Convert Event priority 'override' to 'overwrite'")
+    if any(
+        condition.get("relativeDistanceType") == "cartesianDistance"
+        for condition in _iter(root, "RelativeDistanceCondition")
+    ):
+        issues.append("Convert cartesianDistance to euclidianDistance")
+    return issues
+
+
+def _convert_to_osc_1_1(root: ET.Element) -> list[str]:
+    actions: list[str] = []
+    header = _child(root, "FileHeader")
+    if header is None:
+        raise ScenarioCheckerError("FileHeader is missing")
+
+    major = header.get("revMajor", "")
+    minor = header.get("revMinor", "")
+    if major != "1":
+        raise ScenarioCheckerError(
+            f"Unsupported OpenSCENARIO major version {major or '<missing>'}; expected 1"
+        )
+    if minor != "1":
+        header.set("revMinor", "1")
+        actions.append(f"Converted OpenSCENARIO {major}.{minor or '<missing>'} to 1.1")
+
+    variable_declarations = _child(root, "VariableDeclarations")
+    if variable_declarations is not None:
+        root.remove(variable_declarations)
+        actions.append("Removed OpenSCENARIO 1.2 VariableDeclarations")
+
+    priorities_converted = 0
+    for event in _iter(root, "Event"):
+        if event.get("priority") == "override":
+            event.set("priority", "overwrite")
+            priorities_converted += 1
+    if priorities_converted:
+        actions.append(
+            f"Converted {priorities_converted} Event priority value(s) from override to overwrite"
+        )
+
+    distances_converted = 0
+    for condition in _iter(root, "RelativeDistanceCondition"):
+        if condition.get("relativeDistanceType") == "cartesianDistance":
+            condition.set("relativeDistanceType", "euclidianDistance")
+            distances_converted += 1
+    if distances_converted:
+        actions.append(
+            f"Converted {distances_converted} cartesianDistance value(s) to euclidianDistance"
+        )
+    return actions
+
+
+def _parse_xml(path: Path, expected_root: str) -> ET.ElementTree:
+    try:
+        tree = ET.parse(path)
+    except (OSError, ET.ParseError) as error:
+        raise ScenarioCheckerError(f"Cannot parse {path}: {error}") from error
+    if _local_name(tree.getroot().tag) != expected_root:
+        raise ScenarioCheckerError(
+            f"{path} must have <{expected_root}> as its root element"
+        )
+    return tree
+
+
+def _repo_root_from(path: Path) -> Path:
+    for candidate in (path.resolve(), *path.resolve().parents):
+        if (candidate / "carla-simulation").is_dir() and (candidate / "utils").is_dir():
+            return candidate
+    return Path.cwd().resolve()
+
+
+def _resolve_map(
+    scenario_file: Path,
+    root: ET.Element,
+    *,
+    opendrive: Optional[Path],
+    lanelet: Optional[Path],
+) -> MapResolution:
+    logic_element = _path(root, "RoadNetwork", "LogicFile")
+    if logic_element is None or not logic_element.get("filepath", "").strip():
+        raise ScenarioCheckerError("RoadNetwork/LogicFile filepath is missing")
+    logic_file = logic_element.get("filepath", "").strip()
+
+    selected_opendrive = opendrive.resolve() if opendrive else None
+    if selected_opendrive:
+        if selected_opendrive.suffix.lower() != ".xodr":
+            raise ScenarioCheckerError("Uploaded OpenDRIVE map must end in .xodr")
+        _parse_xml(selected_opendrive, "OpenDRIVE")
+    elif logic_file.lower().endswith(".xodr"):
+        raise ScenarioCheckerError(
+            "OpenDRIVE map referenced by LogicFile must be explicitly uploaded: "
+            f"{logic_file}"
+        )
+
+    if selected_opendrive:
+        selected_lanelet = lanelet.resolve() if lanelet else None
+        if selected_lanelet is None or not selected_lanelet.is_file():
+            raise ScenarioCheckerError(
+                "Custom OpenDRIVE requires an explicitly uploaded Lanelet2 .osm file"
+            )
+        if selected_lanelet.suffix.lower() != ".osm":
+            raise ScenarioCheckerError("Lanelet2 map must end in .osm")
+        _parse_xml(selected_lanelet, "osm")
+        return MapResolution(
+            kind="custom",
+            logic_file=logic_file,
+            opendrive=selected_opendrive,
+            lanelet=selected_lanelet,
+        )
+
+    if lanelet:
+        raise ScenarioCheckerError(
+            "A Lanelet2 upload without a custom OpenDRIVE map is not supported by the importer"
+        )
+    map_name = _canonical_prebuilt_map(logic_file)
+    if not map_name:
+        supported = ", ".join(PREBUILT_MAPS.values())
+        raise ScenarioCheckerError(
+            f"LogicFile references unknown prebuilt map {logic_file!r}; supported: {supported}"
+        )
+    return MapResolution(kind="prebuilt", logic_file=logic_file, map_name=map_name)
+
+
+def _scenario_objects(root: ET.Element) -> list[ET.Element]:
+    return _children(_child(root, "Entities"), "ScenarioObject")
+
+
+def _actor_payload(actor: ET.Element) -> Optional[ET.Element]:
+    return next(
+        (
+            element
+            for element in list(actor)
+            if _local_name(element.tag) in {"Vehicle", "Pedestrian"}
+        ),
+        None,
+    )
+
+
+def _actor_type(actor: ET.Element) -> str:
+    payload = _actor_payload(actor)
+    properties = _child(payload, "Properties")
+    for prop in _children(properties, "Property"):
+        if prop.get("name") == "type":
+            return prop.get("value", "")
+    return ""
+
+
+def _select_ego(
+    root: ET.Element,
+    requested_ego: str,
+    *,
+    allow_repair: bool,
+) -> tuple[Optional[ET.Element], list[str]]:
+    actors = _scenario_objects(root)
+    ego_actors = [
+        actor
+        for actor in actors
+        if actor.get("name") == "ego_vehicle" or _actor_type(actor) == "ego_vehicle"
+    ]
+    unique_ego = list({id(actor): actor for actor in ego_actors}.values())
+    if len(unique_ego) > 1:
+        return None, ["Multiple actors are marked as ego_vehicle"]
+    if unique_ego:
+        if requested_ego and unique_ego[0].get("name") != requested_ego:
+            return None, [
+                f"Requested ego actor {requested_ego!r} conflicts with existing ego_vehicle"
+            ]
+        return unique_ego[0], []
+
+    vehicle_actors = []
+    for actor in actors:
+        payload = _actor_payload(actor)
+        if payload is not None and _local_name(payload.tag) == "Vehicle":
+            vehicle_actors.append(actor)
+    if requested_ego:
+        requested = next(
+            (actor for actor in vehicle_actors if actor.get("name") == requested_ego),
+            None,
+        )
+        if requested is None:
+            return None, [f"Requested ego actor does not exist or is not a Vehicle: {requested_ego}"]
+        return requested, []
+    if not vehicle_actors:
+        return None, ["Scenario contains no inline Vehicle actor that can become ego_vehicle"]
+    if not allow_repair:
+        return None, [
+            "Scenario has no ego_vehicle; import it to select and normalize an ego actor"
+        ]
+    return vehicle_actors[0], []
+
+
+def _ego_private(root: ET.Element, ego_name: str) -> Optional[ET.Element]:
+    actions = _path(root, "Storyboard", "Init", "Actions")
+    for private in _children(actions, "Private"):
+        if private.get("entityRef") == ego_name:
+            return private
+    return None
+
+
+def _ego_controller_actions(root: ET.Element, ego_name: str) -> list[ET.Element]:
+    private = _ego_private(root, ego_name)
+    return [
+        action
+        for action in _children(private, "PrivateAction")
+        if _child(action, "ControllerAction") is not None
+    ]
+
+
+def _has_normalized_ego_controller(root: ET.Element, ego_name: str) -> bool:
+    controller_actions = _ego_controller_actions(root, ego_name)
+    if len(controller_actions) != 1:
+        return False
+    assign_actions = list(_iter(controller_actions[0], "AssignControllerAction"))
+    if len(assign_actions) != 1:
+        return False
+    return any(
+        prop.get("name") == "module" and prop.get("value") == ROS_CONTROLLER_MODULE
+        for prop in _iter(assign_actions[0], "Property")
+    )
+
+
+def _object_controllers(root: ET.Element) -> list[ET.Element]:
+    return [
+        controller
+        for actor in _scenario_objects(root)
+        for controller in _children(actor, "ObjectController")
+    ]
+
+
+def _catalog_references_outside_object_controllers(
+    root: ET.Element,
+) -> list[ET.Element]:
+    replaced_reference_ids = {
+        id(reference)
+        for controller in _object_controllers(root)
+        for reference in _iter(controller, "CatalogReference")
+    }
+    return [
+        reference
+        for reference in _iter(root, "CatalogReference")
+        if id(reference) not in replaced_reference_ids
+    ]
+
+
+def _ego_route_event(root: ET.Element, ego_name: str) -> str:
+    for maneuver_group in _iter(root, "ManeuverGroup"):
+        actors = _child(maneuver_group, "Actors")
+        if not any(
+            ref.get("entityRef") == ego_name for ref in _children(actors, "EntityRef")
+        ):
+            continue
+        for event in _iter(maneuver_group, "Event"):
+            if any(True for _ in _iter(event, "AssignRouteAction")):
+                return event.get("name", "")
+    return ""
+
+
+def _missing_rts_count(root: ET.Element, ego_name: str) -> int:
+    missing = 0
+    for maneuver_group in _iter(root, "ManeuverGroup"):
+        actors = {
+            ref.get("entityRef", "")
+            for ref in _children(_child(maneuver_group, "Actors"), "EntityRef")
+        }
+        if not actors or ego_name in actors:
+            continue
+        for trajectory in _iter(maneuver_group, "Trajectory"):
+            declarations = _child(trajectory, "ParameterDeclarations")
+            if not any(
+                parameter.get("name") == "rts-mode"
+                for parameter in _children(declarations, "ParameterDeclaration")
+            ):
+                missing += 1
+    return missing
+
+
+def _missing_criteria(root: ET.Element) -> list[str]:
+    storyboard = _child(root, "Storyboard")
+    stop_trigger = _child(storyboard, "StopTrigger")
+    existing = {
+        condition.get("name", "") for condition in _iter(stop_trigger, "Condition")
+    }
+    return [name for name in CRITERIA if name not in existing]
+
+
+def _validate_expected_map(
+    report: ScenarioReport,
+    *,
+    expected_map: str,
+    expected_opendrive: Optional[Path],
+    expected_lanelet: Optional[Path],
+) -> None:
+    resolution = report.map_resolution
+    if resolution is None:
+        return
+    if expected_map:
+        expected_canonical = _canonical_prebuilt_map(expected_map)
+        if resolution.kind != "prebuilt" or resolution.map_name != expected_canonical:
+            report.errors.append(
+                f"Configured prebuilt map {expected_map!r} does not match LogicFile {resolution.logic_file!r}"
+            )
+    if expected_opendrive:
+        if resolution.kind != "custom" or resolution.opendrive is None:
+            report.errors.append(
+                "Configured CUSTOM_OPENDRIVE does not match the prebuilt map in LogicFile"
+            )
+        else:
+            configured = expected_opendrive.resolve()
+            if configured.parent != report.scenario.parent.resolve():
+                report.errors.append(
+                    "CUSTOM_OPENDRIVE must be in the same directory as the "
+                    f"OpenSCENARIO file: {configured}"
+                )
+            logic_reference = Path(resolution.logic_file.replace("\\", "/"))
+            if (
+                logic_reference.is_absolute()
+                or logic_reference.parent != Path(".")
+                or logic_reference.name != configured.name
+            ):
+                report.errors.append(
+                    f"LogicFile filepath must reference the configured OpenDRIVE in the "
+                    "same directory as the OpenSCENARIO file; expected only the filename "
+                    f"{configured.name!r}, got {resolution.logic_file!r}"
+                )
+            try:
+                matches = resolution.opendrive.samefile(configured)
+            except OSError:
+                matches = resolution.opendrive.resolve() == configured
+            if not matches:
+                report.errors.append(
+                    f"Configured OpenDRIVE {configured} does not match LogicFile map {resolution.opendrive}"
+                )
+    if expected_lanelet:
+        if resolution.lanelet is None:
+            report.errors.append("Configured CUSTOM_LANELET has no matching custom OpenDRIVE map")
+        else:
+            configured = expected_lanelet.resolve()
+            if configured.parent != report.scenario.parent.resolve():
+                report.errors.append(
+                    "CUSTOM_LANELET must be in the same directory as the "
+                    f"OpenSCENARIO file: {configured}"
+                )
+            try:
+                matches = resolution.lanelet.samefile(configured)
+            except OSError:
+                matches = resolution.lanelet.resolve() == configured
+            if not matches:
+                report.errors.append(
+                    f"Configured Lanelet2 map {configured} does not match resolved map {resolution.lanelet}"
+                )
+
+
+def validate_scenario(
+    scenario_file: Path | str,
+    *,
+    opendrive: Path | str | None = None,
+    lanelet: Path | str | None = None,
+    ego: str = "",
+    repo_root: Path | str | None = None,
+    expected_map: str = "",
+    expected_opendrive: Path | str | None = None,
+    expected_lanelet: Path | str | None = None,
+    allow_repair: bool = False,
+) -> ScenarioReport:
+    scenario_path = Path(scenario_file).resolve()
+    report = ScenarioReport(scenario=scenario_path)
+    try:
+        tree = _parse_xml(scenario_path, "OpenSCENARIO")
+        root = tree.getroot()
+        version_issues = _version_conversion_issues(root)
+        unrepairable_version = any(
+            issue.startswith("Unsupported") or issue == "FileHeader is missing"
+            for issue in version_issues
+        )
+        if unrepairable_version or not allow_repair:
+            report.errors.extend(version_issues)
+        else:
+            report.planned_changes.extend(version_issues)
+        report.map_resolution = _resolve_map(
+            scenario_path,
+            root,
+            opendrive=Path(opendrive) if opendrive else None,
+            lanelet=Path(lanelet) if lanelet else None,
+        )
+        ego_actor, ego_errors = _select_ego(
+            root,
+            ego,
+            allow_repair=allow_repair,
+        )
+        report.errors.extend(ego_errors)
+        if ego_actor is not None:
+            report.ego_actor = ego_actor.get("name", "")
+            if report.ego_actor != "ego_vehicle":
+                report.planned_changes.append(
+                    f"Rename ego actor {report.ego_actor!r} to 'ego_vehicle'"
+                )
+            if _actor_type(ego_actor) != "ego_vehicle":
+                report.planned_changes.append("Set ego actor type=ego_vehicle")
+            if not _has_normalized_ego_controller(root, report.ego_actor):
+                if allow_repair:
+                    report.planned_changes.append(
+                        "Replace ego ControllerAction elements with RosRouteController"
+                    )
+                else:
+                    report.errors.append(
+                        "ego_vehicle controller setup is not normalized; import the "
+                        "scenario to replace it with RosRouteController"
+                    )
+            missing_rts = _missing_rts_count(root, report.ego_actor)
+            if missing_rts:
+                report.planned_changes.append(
+                    f"Add rts-mode=rts to {missing_rts} non-ego trajectory/trajectories"
+                )
+
+        object_controller_count = len(_object_controllers(root))
+        if object_controller_count:
+            message = (
+                f"Remove {object_controller_count} ScenarioObject "
+                "ObjectController element(s)"
+            )
+            if allow_repair:
+                report.planned_changes.append(message)
+            else:
+                report.errors.append(
+                    f"{message}; import the scenario to use runtime controllers"
+                )
+        remaining_catalog_references = _catalog_references_outside_object_controllers(root)
+        if remaining_catalog_references:
+            report.errors.append(
+                f"Scenario contains {len(remaining_catalog_references)} unsupported "
+                "external CatalogReference element(s)"
+            )
+        old_precipitation = sum(
+            1 for element in _iter(root, "Precipitation") if "intensity" in element.attrib
+        )
+        if old_precipitation:
+            report.planned_changes.append(
+                f"Rename intensity on {old_precipitation} Precipitation element(s)"
+            )
+
+        init_actions = _path(root, "Storyboard", "Init", "Actions")
+        teleport_count = 0
+        for teleport in _iter(init_actions, "TeleportAction"):
+            world_position = next(iter(_iter(teleport, "WorldPosition")), None)
+            if world_position is None:
+                report.errors.append("Init TeleportAction has no WorldPosition")
+                continue
+            try:
+                float(world_position.get("z", "0"))
+            except ValueError:
+                report.errors.append("Init TeleportAction WorldPosition requires a numeric z value")
+                continue
+            teleport_count += 1
+        if teleport_count:
+            report.planned_changes.append(
+                f"Raise {teleport_count} initial TeleportAction position(s) by 0.1 m"
+            )
+
+        missing_criteria = _missing_criteria(root)
+        if missing_criteria:
+            report.planned_changes.append(
+                f"Add {len(missing_criteria)} missing ScenarioRunner criterion/criteria"
+            )
+
+        _validate_expected_map(
+            report,
+            expected_map=expected_map,
+            expected_opendrive=Path(expected_opendrive) if expected_opendrive else None,
+            expected_lanelet=Path(expected_lanelet) if expected_lanelet else None,
+        )
+    except ScenarioCheckerError as error:
+        report.errors.append(str(error))
+    return report
+
+
+def validate_scenario_folder(
+    scenario_folder: Path | str,
+    *,
+    repo_root: Path | str | None = None,
+    expected_map: str = "",
+    expected_opendrive: Path | str | None = None,
+    lanelet: Path | str | None = None,
+) -> dict[str, object]:
+    folder = Path(scenario_folder).resolve()
+    if not folder.is_dir():
+        return {
+            "valid": False,
+            "folder": str(folder),
+            "checked": 0,
+            "errors": [f"Scenario folder does not exist: {folder}"],
+            "warnings": [],
+        }
+
+    custom_opendrive = Path(expected_opendrive).resolve() if expected_opendrive else None
+    selected_reference = custom_opendrive.name if custom_opendrive else expected_map
+    selected_normalized = _normalize_map_reference(selected_reference)
+    errors: list[str] = []
+    warnings: list[str] = []
+    checked = 0
+
+    for scenario in sorted(folder.rglob("*.xosc")):
+        if "catalogs" in {part.lower() for part in scenario.parts}:
+            continue
+        try:
+            tree = _parse_xml(scenario, "OpenSCENARIO")
+            logic = _path(tree.getroot(), "RoadNetwork", "LogicFile")
+            logic_file = logic.get("filepath", "") if logic is not None else ""
+            if custom_opendrive:
+                logic_reference = Path(logic_file.replace("\\", "/"))
+                if (
+                    scenario.parent.resolve() != custom_opendrive.parent
+                    or logic_reference.is_absolute()
+                    or logic_reference.parent != Path(".")
+                    or logic_reference.name != custom_opendrive.name
+                ):
+                    continue
+            elif selected_normalized and _normalize_map_reference(logic_file) != selected_normalized:
+                continue
+        except ScenarioCheckerError as error:
+            errors.append(f"{scenario}: {error}")
+            continue
+
+        report = validate_scenario(
+            scenario,
+            repo_root=repo_root,
+            opendrive=expected_opendrive,
+            lanelet=lanelet,
+            expected_map=expected_map,
+            expected_opendrive=expected_opendrive,
+            expected_lanelet=lanelet,
+        )
+        checked += 1
+        errors.extend(f"{scenario}: {message}" for message in report.errors)
+        warnings.extend(f"{scenario}: {message}" for message in report.warnings)
+
+    if selected_normalized and checked == 0:
+        errors.append(f"No OpenSCENARIO files match the configured map {selected_reference!r}")
+
+    return {
+        "valid": not errors,
+        "folder": str(folder),
+        "checked": checked,
+        "errors": errors,
+        "warnings": warnings,
+    }
+
+
+def _runtime_asset_path(value: str, scenario_root: Path) -> Path:
+    reference = Path(value)
+    root = scenario_root.resolve()
+    if reference.is_absolute() and reference.exists():
+        resolved = reference.resolve()
+    else:
+        normalized = value.strip().replace("\\", "/").lstrip("/")
+        repository_prefix = "carla-simulation/scenarios/"
+        if repository_prefix in normalized:
+            normalized = normalized.split(repository_prefix, 1)[1]
+        resolved = (root / normalized).resolve()
+    if not resolved.is_relative_to(root):
+        raise ScenarioCheckerError(
+            f"Runtime scenario path must stay below {root}: {value}"
+        )
+    return resolved
+
+
+def _scenario_root_from_file(scenario: Path) -> Path:
+    for parent in scenario.resolve().parents:
+        if parent.name == "scenarios" and parent.parent.name == "carla-simulation":
+            return parent
+    return scenario.resolve().parent
+
+
+def validate_runtime(
+    target: Path | str,
+    environment: Optional[dict[str, str]] = None,
+) -> dict[str, object]:
+    env = os.environ if environment is None else environment
+    resolved_target = Path(target).resolve()
+    if resolved_target == Path("/"):
+        raise ScenarioCheckerError("Scenario path must not be empty or the filesystem root")
+    if resolved_target.is_dir():
+        target_type = "folder"
+        root = resolved_target
+    elif resolved_target.is_file():
+        target_type = "file"
+        root = _scenario_root_from_file(resolved_target)
+    else:
+        raise ScenarioCheckerError(f"Scenario path does not exist: {resolved_target}")
+
+    expected_map = env.get("MAP", "").strip()
+    opendrive_value = env.get("CUSTOM_OPENDRIVE", "").strip()
+    lanelet_value = env.get("CUSTOM_LANELET", "").strip()
+    expected_opendrive = (
+        _runtime_asset_path(opendrive_value, root) if opendrive_value else None
+    )
+    lanelet = _runtime_asset_path(lanelet_value, root) if lanelet_value else None
+
+    if target_type == "folder":
+        return validate_scenario_folder(
+            root,
+            expected_map=expected_map,
+            expected_opendrive=expected_opendrive,
+            lanelet=lanelet,
+        )
+    report = validate_scenario(
+        resolved_target,
+        opendrive=expected_opendrive,
+        expected_map=expected_map,
+        expected_opendrive=expected_opendrive,
+        expected_lanelet=lanelet,
+        lanelet=lanelet,
+    )
+    return report.to_dict()
+
+
+def _rename_ego(root: ET.Element, actor: ET.Element) -> None:
+    old_name = actor.get("name", "")
+    if old_name == "ego_vehicle":
+        return
+    for element in root.iter():
+        for attribute, value in list(element.attrib.items()):
+            if value == old_name:
+                element.set(attribute, "ego_vehicle")
+
+
+def _ensure_actor_types(root: ET.Element, ego_actor: ET.Element) -> None:
+    for actor in _scenario_objects(root):
+        payload = _actor_payload(actor)
+        if payload is None:
+            continue
+        properties = _child(payload, "Properties")
+        if properties is None:
+            properties = _subelement(payload, "Properties")
+        property_type = next(
+            (
+                prop
+                for prop in _children(properties, "Property")
+                if prop.get("name") == "type"
+            ),
+            None,
+        )
+        if property_type is None:
+            property_type = _subelement(properties, "Property", {"name": "type"})
+        property_type.set(
+            "value",
+            "ego_vehicle" if actor is ego_actor else "other_vehicle",
+        )
+
+
+def _remove_object_controllers(root: ET.Element) -> int:
+    removed = 0
+    for actor in _scenario_objects(root):
+        for controller in _children(actor, "ObjectController"):
+            actor.remove(controller)
+            removed += 1
+    return removed
+
+
+def _clear_catalog_locations(root: ET.Element) -> int:
+    catalog_locations = _child(root, "CatalogLocations")
+    if catalog_locations is None:
+        return 0
+    removed = len(list(catalog_locations))
+    catalog_locations.clear()
+    return removed
+
+
+def _replace_ros_controller(root: ET.Element) -> int:
+    actions = _path(root, "Storyboard", "Init", "Actions")
+    if actions is None:
+        raise ScenarioCheckerError("Storyboard/Init/Actions is required to add ego controller")
+    ego_private = _ego_private(root, "ego_vehicle")
+    if ego_private is None:
+        ego_private = _subelement(actions, "Private", {"entityRef": "ego_vehicle"})
+
+    removed = 0
+    for private_action in list(_children(ego_private, "PrivateAction")):
+        if _child(private_action, "ControllerAction") is not None:
+            ego_private.remove(private_action)
+            removed += 1
+
+    private_action = _subelement(ego_private, "PrivateAction")
+    controller_action = _subelement(private_action, "ControllerAction")
+    override = _subelement(controller_action, "OverrideControllerValueAction")
+    for name in ("Throttle", "Brake", "Clutch", "ParkingBrake", "SteeringWheel"):
+        _subelement(override, name, {"value": "0", "active": "false"})
+    _subelement(override, "Gear", {"number": "0", "active": "false"})
+    assign = _subelement(controller_action, "AssignControllerAction")
+    controller = _subelement(assign, "Controller", {"name": "RosRouteController"})
+    properties = _subelement(controller, "Properties")
+    _subelement(
+        properties,
+        "Property",
+        {"name": "module", "value": ROS_CONTROLLER_MODULE},
+    )
+    return removed
+
+
+def _ensure_rts(root: ET.Element) -> int:
+    added = 0
+    for maneuver_group in _iter(root, "ManeuverGroup"):
+        actors = {
+            ref.get("entityRef", "")
+            for ref in _children(_child(maneuver_group, "Actors"), "EntityRef")
+        }
+        if not actors or "ego_vehicle" in actors:
+            continue
+        for trajectory in _iter(maneuver_group, "Trajectory"):
+            declarations = _child(trajectory, "ParameterDeclarations")
+            if declarations is None:
+                declarations = ET.Element(f"{_namespace(trajectory)}ParameterDeclarations")
+                trajectory.insert(0, declarations)
+            existing = next(
+                (
+                    parameter
+                    for parameter in _children(declarations, "ParameterDeclaration")
+                    if parameter.get("name") == "rts-mode"
+                ),
+                None,
+            )
+            if existing is None:
+                _subelement(
+                    declarations,
+                    "ParameterDeclaration",
+                    {"name": "rts-mode", "value": "rts", "parameterType": "string"},
+                )
+                added += 1
+    return added
+
+
+def _convert_weather(root: ET.Element) -> int:
+    converted = 0
+    for precipitation in _iter(root, "Precipitation"):
+        if "intensity" not in precipitation.attrib:
+            continue
+        if "precipitationIntensity" not in precipitation.attrib:
+            precipitation.set("precipitationIntensity", precipitation.get("intensity", ""))
+        del precipitation.attrib["intensity"]
+        converted += 1
+    return converted
+
+
+def _adjust_teleports(root: ET.Element) -> int:
+    adjusted = 0
+    init_actions = _path(root, "Storyboard", "Init", "Actions")
+    for teleport in _iter(init_actions, "TeleportAction"):
+        world_position = next(iter(_iter(teleport, "WorldPosition")), None)
+        if world_position is None:
+            raise ScenarioCheckerError("Init TeleportAction has no WorldPosition")
+        try:
+            z_value = float(world_position.get("z", "0"))
+        except ValueError as error:
+            raise ScenarioCheckerError(
+                "Init TeleportAction WorldPosition requires a numeric z value"
+            ) from error
+        world_position.set("z", f"{z_value + 0.1:.12g}")
+        adjusted += 1
+    return adjusted
+
+
+def _condition_group(stop_trigger: ET.Element) -> ET.Element:
+    return _subelement(stop_trigger, "ConditionGroup")
+
+
+def _ensure_act_stop_trigger(
+    root: ET.Element,
+    *,
+    timeout: Optional[float],
+    stop_on_ego_route_complete: bool,
+) -> list[str]:
+    actions = []
+    stories = _children(_child(root, "Storyboard"), "Story")
+    acts = _children(stories[-1], "Act") if stories else []
+    if not acts:
+        return actions
+    act = acts[-1]
+    stop_trigger = _child(act, "StopTrigger")
+    if stop_trigger is None:
+        stop_trigger = _subelement(act, "StopTrigger")
+
+    if timeout is not None and not any(True for _ in _iter(stop_trigger, "SimulationTimeCondition")):
+        group = _condition_group(stop_trigger)
+        condition = _subelement(
+            group,
+            "Condition",
+            {"name": "OpenADSimTimeout", "delay": "0", "conditionEdge": "rising"},
+        )
+        by_value = _subelement(condition, "ByValueCondition")
+        _subelement(
+            by_value,
+            "SimulationTimeCondition",
+            {"value": f"{timeout:g}", "rule": "greaterThan"},
+        )
+        actions.append(f"Added {timeout:g}s Act timeout")
+
+    if stop_on_ego_route_complete:
+        event_name = _ego_route_event(root, "ego_vehicle")
+        existing_refs = {
+            condition.get("storyboardElementRef", "")
+            for condition in _iter(stop_trigger, "StoryboardElementStateCondition")
+            if condition.get("state") == "completeState"
+        }
+        if event_name and event_name not in existing_refs:
+            group = _condition_group(stop_trigger)
+            condition = _subelement(
+                group,
+                "Condition",
+                {"name": "EgoRouteDone", "delay": "0", "conditionEdge": "rising"},
+            )
+            by_value = _subelement(condition, "ByValueCondition")
+            _subelement(
+                by_value,
+                "StoryboardElementStateCondition",
+                {
+                    "storyboardElementType": "event",
+                    "storyboardElementRef": event_name,
+                    "state": "completeState",
+                },
+            )
+            actions.append(f"Added EgoRouteDone condition for event {event_name}")
+    return actions
+
+
+def _ensure_criteria(root: ET.Element, driven_distance: float) -> list[str]:
+    storyboard = _child(root, "Storyboard")
+    if storyboard is None:
+        raise ScenarioCheckerError("Storyboard is required to add ScenarioRunner criteria")
+    stop_trigger = _child(storyboard, "StopTrigger")
+    if stop_trigger is None:
+        stop_trigger = _subelement(storyboard, "StopTrigger")
+
+    existing = {
+        condition.get("name", "") for condition in _iter(stop_trigger, "Condition")
+    }
+    criteria_group = next(
+        (
+            group
+            for group in _children(stop_trigger, "ConditionGroup")
+            if any(
+                condition.get("name", "").startswith("criteria_")
+                for condition in _children(group, "Condition")
+            )
+        ),
+        None,
+    )
+    if criteria_group is None:
+        criteria_group = _condition_group(stop_trigger)
+
+    added = []
+    for name in CRITERIA:
+        if name in existing:
+            continue
+        condition = _subelement(
+            criteria_group,
+            "Condition",
+            {"name": name, "delay": "0.0", "conditionEdge": "rising"},
+        )
+        by_value = _subelement(condition, "ByValueCondition")
+        if name == "criteria_DrivenDistanceTest":
+            attributes = {
+                "parameterRef": "distance_success",
+                "value": f"{driven_distance:g}",
+                "rule": "greaterThan",
+            }
+        else:
+            attributes = {"parameterRef": "", "value": "0", "rule": "lessThan"}
+        _subelement(by_value, "ParameterCondition", attributes)
+        added.append(name)
+    return added
+
+
+def _sanitize_name(value: str) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9._-]+", "_", value.strip())
+    normalized = normalized.strip("._-")
+    return normalized
+
+
+def _available_target(output_root: Path, base_name: str) -> Path:
+    candidate = output_root / base_name
+    index = 2
+    while candidate.exists():
+        candidate = output_root / f"{base_name}_{index}"
+        index += 1
+    return candidate
+
+
+def _write_xml(tree: ET.ElementTree, path: Path) -> None:
+    ET.indent(tree, space="  ")
+    tree.write(path, encoding="utf-8", xml_declaration=True)
+
+
+def import_scenario(
+    scenario_file: Path | str,
+    *,
+    output_root: Path | str,
+    name: str = "",
+    opendrive: Path | str | None = None,
+    lanelet: Path | str | None = None,
+    ego: str = "",
+    timeout: Optional[float] = 60.0,
+    stop_on_ego_route_complete: bool = True,
+    driven_distance: float = 30.0,
+    repo_root: Path | str | None = None,
+) -> ImportResult:
+    if timeout is not None and timeout <= 0:
+        raise ScenarioCheckerError("Scenario timeout must be greater than zero")
+    if driven_distance <= 0:
+        raise ScenarioCheckerError("Driven-distance criterion must be greater than zero")
+    scenario_path = Path(scenario_file).resolve()
+    root_path = Path(repo_root).resolve() if repo_root else _repo_root_from(scenario_path)
+    report = validate_scenario(
+        scenario_path,
+        opendrive=opendrive,
+        lanelet=lanelet,
+        ego=ego,
+        repo_root=root_path,
+        allow_repair=True,
+    )
+    if not report.is_valid or report.map_resolution is None:
+        raise ScenarioCheckerError("; ".join(report.errors))
+
+    tree = _parse_xml(scenario_path, "OpenSCENARIO")
+    root = tree.getroot()
+    ego_actor, ego_errors = _select_ego(root, ego, allow_repair=True)
+    if ego_actor is None:
+        raise ScenarioCheckerError("; ".join(ego_errors))
+
+    actions: list[str] = []
+    import_warnings = list(report.warnings)
+    actions.extend(_convert_to_osc_1_1(root))
+    original_ego_name = ego_actor.get("name", "")
+    _rename_ego(root, ego_actor)
+    if original_ego_name != "ego_vehicle":
+        actions.append(f"Renamed ego actor {original_ego_name} to ego_vehicle")
+    object_controllers_removed = _remove_object_controllers(root)
+    if object_controllers_removed:
+        actions.append(
+            f"Removed {object_controllers_removed} ScenarioObject ObjectController element(s)"
+        )
+    catalog_locations_cleared = _clear_catalog_locations(root)
+    if catalog_locations_cleared:
+        actions.append(
+            f"Cleared {catalog_locations_cleared} unused catalog location(s)"
+        )
+    _ensure_actor_types(root, ego_actor)
+    actions.append("Normalized actor type properties")
+    replaced_controller_actions = _replace_ros_controller(root)
+    if replaced_controller_actions:
+        actions.append(
+            f"Replaced {replaced_controller_actions} ego ControllerAction element(s) "
+            "with RosRouteController"
+        )
+    else:
+        actions.append("Added RosRouteController to ego_vehicle")
+
+    rts_added = _ensure_rts(root)
+    if rts_added:
+        actions.append(f"Added rts-mode=rts to {rts_added} non-ego trajectory/trajectories")
+    weather_converted = _convert_weather(root)
+    if weather_converted:
+        actions.append(f"Converted {weather_converted} precipitation attribute(s)")
+    teleport_adjusted = _adjust_teleports(root)
+    if teleport_adjusted:
+        actions.append(f"Raised {teleport_adjusted} initial teleport position(s) by 0.1 m")
+    if stop_on_ego_route_complete and not _ego_route_event(root, "ego_vehicle"):
+        import_warnings.append(
+            "No ego AssignRouteAction event found; route-completion StopTrigger was not added"
+        )
+    actions.extend(
+        _ensure_act_stop_trigger(
+            root,
+            timeout=timeout,
+            stop_on_ego_route_complete=stop_on_ego_route_complete,
+        )
+    )
+    criteria_added = _ensure_criteria(root, driven_distance)
+    if criteria_added:
+        actions.append(f"Added {len(criteria_added)} ScenarioRunner criterion/criteria")
+
+    resolution = report.map_resolution
+    logic_element = _path(root, "RoadNetwork", "LogicFile")
+    assert logic_element is not None
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    base_name = _sanitize_name(name) if name.strip() else timestamp
+    if not base_name:
+        raise ScenarioCheckerError("Import name contains no usable characters")
+    destination_root = Path(output_root).resolve()
+    destination_root.mkdir(parents=True, exist_ok=True)
+    destination = _available_target(destination_root, base_name)
+    staging = Path(tempfile.mkdtemp(prefix=".scenario-import-", dir=destination_root))
+    staging.chmod(0o2775)
+
+    try:
+        scenario_output = staging / f"{destination.name}.xosc"
+        imported_resolution = resolution
+        if resolution.kind == "custom":
+            assert resolution.opendrive is not None and resolution.lanelet is not None
+            opendrive_name = _sanitize_name(resolution.opendrive.stem) + ".xodr"
+            lanelet_name = _sanitize_name(resolution.lanelet.stem) + ".osm"
+            opendrive_output = staging / opendrive_name
+            lanelet_output = staging / lanelet_name
+            shutil.copy2(resolution.opendrive, opendrive_output)
+            shutil.copy2(resolution.lanelet, lanelet_output)
+            logic_element.set("filepath", opendrive_name)
+            imported_resolution = MapResolution(
+                kind="custom",
+                logic_file=opendrive_name,
+                opendrive=destination / opendrive_name,
+                lanelet=destination / lanelet_name,
+            )
+            actions.append(f"Set LogicFile to imported OpenDRIVE {opendrive_name}")
+        else:
+            logic_element.set("filepath", resolution.map_name)
+            imported_resolution = MapResolution(
+                kind="prebuilt",
+                logic_file=resolution.map_name,
+                map_name=resolution.map_name,
+            )
+
+        _write_xml(tree, scenario_output)
+        manifest = {
+            "imported_at": datetime.now(timezone.utc).isoformat(),
+            "source": str(scenario_path),
+            "scenario": f"{destination.name}.xosc",
+            "map": {
+                "type": imported_resolution.kind,
+                "map_name": imported_resolution.map_name,
+                "opendrive": imported_resolution.opendrive.name if imported_resolution.opendrive else "",
+                "lanelet": imported_resolution.lanelet.name if imported_resolution.lanelet else "",
+            },
+            "actions": actions,
+            "teleport_z_adjusted": True,
+        }
+        (staging / "import.json").write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        staging.rename(destination)
+    except Exception:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+
+    return ImportResult(
+        directory=destination,
+        scenario_file=destination / f"{destination.name}.xosc",
+        map_resolution=imported_resolution,
+        actions=tuple(actions),
+        warnings=tuple(import_warnings),
+        repo_root=root_path,
+    )
+
+
+def _add_map_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--opendrive", help="custom OpenDRIVE file overriding LogicFile")
+    parser.add_argument("--lanelet", help="matching Lanelet2 .osm file")
+    parser.add_argument("--ego", default="", help="actor to use when ego_vehicle is missing")
+    parser.add_argument("--repo-root", help="OpenADSim repository root")
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate and import OpenSCENARIO bundles for OpenADSim/CARLA"
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    validate = subparsers.add_parser("validate", help="validate without modifying files")
+    validate.add_argument("scenario")
+    _add_map_arguments(validate)
+    validate.add_argument("--expected-map", default="")
+    validate.add_argument("--expected-opendrive")
+    validate.add_argument("--expected-lanelet")
+
+    validate_folder = subparsers.add_parser(
+        "validate-folder",
+        help="validate scenarios matching one active map",
+    )
+    validate_folder.add_argument("folder")
+    validate_folder.add_argument("--repo-root")
+    validate_folder.add_argument("--expected-map", default="")
+    validate_folder.add_argument("--expected-opendrive")
+    validate_folder.add_argument("--lanelet")
+    validate_folder.add_argument("--json", action="store_true")
+
+    validate_runtime_parser = subparsers.add_parser(
+        "validate-runtime",
+        help="validate the active scenario configuration from environment variables",
+    )
+    validate_runtime_parser.add_argument("target")
+    validate_runtime_parser.add_argument("--json", action="store_true")
+
+    importer = subparsers.add_parser("import", help="validate and create an import bundle")
+    importer.add_argument("scenario")
+    _add_map_arguments(importer)
+    importer.add_argument("--output-root", required=True)
+    importer.add_argument("--name", default="")
+    importer.add_argument("--timeout", type=float, default=60.0)
+    importer.add_argument("--no-ego-route-stop", action="store_true")
+    importer.add_argument("--driven-distance", type=float, default=30.0)
+    return parser.parse_args()
+
+
+def _print_report(data: dict[str, object], as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(data, indent=2, sort_keys=True))
+        return
+    if data.get("valid"):
+        target = data.get("scenario_file") or data.get("scenario") or data.get("folder", "")
+        print(f"Valid: {target}")
+        if "checked" in data:
+            print(f"  checked: {data['checked']}")
+        for action in data.get("actions", data.get("planned_changes", [])):
+            print(f"  - {action}")
+        for warning in data.get("warnings", []):
+            print(f"  warning: {warning}")
+    else:
+        for error in data.get("errors", []):
+            print(f"Error: {error}", file=sys.stderr)
+
+
+def main() -> int:
+    args = _parse_args()
+    try:
+        if args.command == "validate":
+            report = validate_scenario(
+                args.scenario,
+                opendrive=args.opendrive,
+                lanelet=args.lanelet,
+                ego=args.ego,
+                repo_root=args.repo_root,
+                expected_map=args.expected_map,
+                expected_opendrive=args.expected_opendrive,
+                expected_lanelet=args.expected_lanelet,
+            )
+            data = report.to_dict()
+            _print_report(data, args.json)
+            return 0 if report.is_valid else 1
+
+        if args.command == "validate-folder":
+            data = validate_scenario_folder(
+                args.folder,
+                repo_root=args.repo_root,
+                expected_map=args.expected_map,
+                expected_opendrive=args.expected_opendrive,
+                lanelet=args.lanelet,
+            )
+            _print_report(data, args.json)
+            return 0 if data["valid"] else 1
+
+        if args.command == "validate-runtime":
+            data = validate_runtime(args.target)
+            _print_report(data, args.json)
+            return 0 if data["valid"] else 1
+
+        repo_root = Path(args.repo_root).resolve() if args.repo_root else None
+        result = import_scenario(
+            args.scenario,
+            output_root=args.output_root,
+            name=args.name,
+            opendrive=args.opendrive,
+            lanelet=args.lanelet,
+            ego=args.ego,
+            timeout=args.timeout,
+            stop_on_ego_route_complete=not args.no_ego_route_stop,
+            driven_distance=args.driven_distance,
+            repo_root=repo_root,
+        )
+        data = result.to_dict()
+        _print_report(data, args.json)
+        return 0
+    except ScenarioCheckerError as error:
+        data = {"valid": False, "errors": [str(error)], "warnings": []}
+        _print_report(data, args.json)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/utils/scenario-checker/scenario_checker.py
+++ b/utils/scenario-checker/scenario_checker.py
@@ -395,17 +395,31 @@ def _ego_private(root: ET.Element, ego_name: str) -> Optional[ET.Element]:
 
 
 def _ego_controller_actions(root: ET.Element, ego_name: str) -> list[ET.Element]:
-    private = _ego_private(root, ego_name)
-    return [
+    actions = _path(root, "Storyboard", "Init", "Actions")
+    result = [
         action
+        for private in _children(actions, "Private")
+        if private.get("entityRef") == ego_name
         for action in _children(private, "PrivateAction")
         if _child(action, "ControllerAction") is not None
     ]
+    for group in _iter(root, "ManeuverGroup"):
+        actors = _child(group, "Actors")
+        refs = {ref.get("entityRef") for ref in _children(actors, "EntityRef")}
+        if ego_name in refs:
+            result.extend(
+                action for action in _iter(group, "PrivateAction")
+                if _child(action, "ControllerAction") is not None
+            )
+    return result
 
 
 def _has_normalized_ego_controller(root: ET.Element, ego_name: str) -> bool:
     controller_actions = _ego_controller_actions(root, ego_name)
     if len(controller_actions) != 1:
+        return False
+    init = _path(root, "Storyboard", "Init", "Actions")
+    if controller_actions[0] not in list(_iter(init, "PrivateAction")):
         return False
     assign_actions = list(_iter(controller_actions[0], "AssignControllerAction"))
     if len(assign_actions) != 1:
@@ -870,11 +884,34 @@ def _replace_ros_controller(root: ET.Element) -> int:
     if ego_private is None:
         ego_private = _subelement(actions, "Private", {"entityRef": "ego_vehicle"})
 
-    removed = 0
-    for private_action in list(_children(ego_private, "PrivateAction")):
-        if _child(private_action, "ControllerAction") is not None:
-            ego_private.remove(private_action)
-            removed += 1
+    # Shared maneuver actions cannot be removed without changing other actors.
+    for group in _iter(root, "ManeuverGroup"):
+        refs = {
+            ref.get("entityRef")
+            for ref in _children(_child(group, "Actors"), "EntityRef")
+        }
+        if "ego_vehicle" in refs and len(refs) > 1 and list(_iter(group, "ControllerAction")):
+            raise ScenarioCheckerError(
+                "Ego ControllerAction is shared with other actors; split the "
+                "ManeuverGroup by actor before importing"
+            )
+    existing = _ego_controller_actions(root, "ego_vehicle")
+    parents = {child: parent for parent in root.iter() for child in parent}
+    required_children = {
+        "Action": "PrivateAction", "Event": "Action",
+        "Maneuver": "Event", "ManeuverGroup": "Maneuver",
+    }
+    for action in existing:
+        parent = parents[action]
+        parent.remove(action)
+        # Remove storyboard containers left without their required action children.
+        while (required := required_children.get(_local_name(parent.tag))):
+            if _children(parent, required):
+                break
+            owner = parents[parent]
+            owner.remove(parent)
+            parent = owner
+    removed = len(existing)
 
     private_action = _subelement(ego_private, "PrivateAction")
     controller_action = _subelement(private_action, "ControllerAction")

--- a/utils/scenario-checker/test_scenario_checker.py
+++ b/utils/scenario-checker/test_scenario_checker.py
@@ -1,0 +1,477 @@
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from stat import S_IMODE
+
+from scenario_checker import (
+    CRITERIA,
+    ScenarioCheckerError,
+    import_scenario,
+    validate_runtime,
+    validate_scenario,
+)
+
+
+SCENARIO = """<?xml version="1.0"?>
+<OpenSCENARIO>
+  <FileHeader revMajor="1" revMinor="1"/>
+  <RoadNetwork><LogicFile filepath="campus"/></RoadNetwork>
+  <Entities>
+    <ScenarioObject name="car_1">
+      <Vehicle name="vehicle.test" vehicleCategory="car"><Properties/></Vehicle>
+    </ScenarioObject>
+    <ScenarioObject name="car_2">
+      <Vehicle name="vehicle.test" vehicleCategory="car"><Properties/></Vehicle>
+    </ScenarioObject>
+  </Entities>
+  <Storyboard>
+    <Init><Actions>
+      <Private entityRef="car_1"><PrivateAction><TeleportAction><Position><WorldPosition x="0" y="0"/></Position></TeleportAction></PrivateAction></Private>
+      <Private entityRef="car_2"><PrivateAction><TeleportAction><Position><WorldPosition x="1" y="0" z="1"/></Position></TeleportAction></PrivateAction></Private>
+      <GlobalAction><EnvironmentAction><Environment><Weather><Precipitation intensity="0.5" precipitationType="rain"/></Weather></Environment></EnvironmentAction></GlobalAction>
+    </Actions></Init>
+    <Story name="story"><Act name="act">
+      <ManeuverGroup name="ego"><Actors><EntityRef entityRef="car_1"/></Actors><Maneuver><Event name="ego_route"><Action><PrivateAction><RoutingAction><AssignRouteAction><Route/></AssignRouteAction></RoutingAction></PrivateAction></Action></Event></Maneuver></ManeuverGroup>
+      <ManeuverGroup name="other"><Actors><EntityRef entityRef="car_2"/></Actors><Maneuver><Event name="other_route"><Action><PrivateAction><RoutingAction><FollowTrajectoryAction><TrajectoryRef><Trajectory name="other"><Shape><Polyline><Vertex time="0"><Position><WorldPosition x="0" y="0"/></Position></Vertex></Polyline></Shape></Trajectory></TrajectoryRef></FollowTrajectoryAction></RoutingAction></PrivateAction></Action></Event></Maneuver></ManeuverGroup>
+      <StartTrigger/>
+    </Act></Story>
+    <StopTrigger/>
+  </Storyboard>
+</OpenSCENARIO>
+"""
+
+
+def local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+class ScenarioCheckerTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.scenario = self.root / "source.xosc"
+        self.scenario.write_text(SCENARIO, encoding="utf-8")
+        self.output = self.root / "custom-imports"
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def test_import_applies_targeted_adjustments_and_indexes_duplicates(self):
+        first = import_scenario(
+            self.scenario,
+            output_root=self.output,
+            name="demo",
+            repo_root=self.root,
+        )
+        second = import_scenario(
+            self.scenario,
+            output_root=self.output,
+            name="demo",
+            repo_root=self.root,
+        )
+
+        self.assertEqual(first.directory.name, "demo")
+        self.assertEqual(second.directory.name, "demo_2")
+        self.assertEqual(S_IMODE(first.directory.stat().st_mode), 0o2775)
+        self.assertEqual(S_IMODE(second.directory.stat().st_mode), 0o2775)
+        root = ET.parse(first.scenario_file).getroot()
+
+        actors = [element for element in root.iter() if local_name(element.tag) == "ScenarioObject"]
+        self.assertEqual(actors[0].get("name"), "ego_vehicle")
+        refs = [
+            element.get("entityRef")
+            for element in root.iter()
+            if "entityRef" in element.attrib
+        ]
+        self.assertIn("ego_vehicle", refs)
+        self.assertTrue(any(local_name(element.tag) == "AssignControllerAction" for element in root.iter()))
+
+        rts_parameters = [
+            element
+            for element in root.iter()
+            if local_name(element.tag) == "ParameterDeclaration"
+            and element.get("name") == "rts-mode"
+        ]
+        self.assertEqual(len(rts_parameters), 1)
+        self.assertEqual(rts_parameters[0].get("value"), "rts")
+
+        precipitation = next(
+            element for element in root.iter() if local_name(element.tag) == "Precipitation"
+        )
+        self.assertNotIn("intensity", precipitation.attrib)
+        self.assertEqual(precipitation.get("precipitationIntensity"), "0.5")
+
+        teleports = [
+            next(
+                child
+                for child in element.iter()
+                if local_name(child.tag) == "WorldPosition"
+            )
+            for element in root.iter()
+            if local_name(element.tag) == "TeleportAction"
+        ]
+        self.assertEqual([position.get("z") for position in teleports], ["0.1", "1.1"])
+
+        conditions = [
+            element for element in root.iter() if local_name(element.tag) == "Condition"
+        ]
+        condition_names = {element.get("name") for element in conditions}
+        self.assertTrue(set(CRITERIA).issubset(condition_names))
+        self.assertIn("EgoRouteDone", condition_names)
+        self.assertIn("OpenADSimTimeout", condition_names)
+
+    def test_uploaded_opendrive_overrides_prebuilt_logic_file(self):
+        opendrive = self.root / "custom.xodr"
+        lanelet = self.root / "custom.osm"
+        opendrive.write_text("<OpenDRIVE/>", encoding="utf-8")
+        lanelet.write_text("<osm/>", encoding="utf-8")
+
+        result = import_scenario(
+            self.scenario,
+            output_root=self.output,
+            name="custom",
+            opendrive=opendrive,
+            lanelet=lanelet,
+            repo_root=self.root,
+        )
+
+        root = ET.parse(result.scenario_file).getroot()
+        logic_file = next(
+            element for element in root.iter() if local_name(element.tag) == "LogicFile"
+        )
+        self.assertEqual(logic_file.get("filepath"), "custom.xodr")
+        self.assertTrue((result.directory / "custom.xodr").is_file())
+        self.assertTrue((result.directory / "custom.osm").is_file())
+
+    def test_existing_ego_controller_is_replaced(self):
+        controlled = self.root / "controlled.xosc"
+        controlled.write_text(
+            SCENARIO.replace(
+                '<Private entityRef="car_1"><PrivateAction><TeleportAction>',
+                '<Private entityRef="car_1"><PrivateAction><ControllerAction>'
+                '<ActivateControllerAction lateral="true" longitudinal="true"/>'
+                '</ControllerAction></PrivateAction><PrivateAction><ControllerAction>'
+                '<AssignControllerAction><Controller name="ExistingController"/>'
+                '</AssignControllerAction></ControllerAction></PrivateAction>'
+                '<PrivateAction><TeleportAction>',
+            ),
+            encoding="utf-8",
+        )
+        result = import_scenario(
+            controlled,
+            output_root=self.output,
+            name="controlled",
+            repo_root=self.root,
+        )
+        root = ET.parse(result.scenario_file).getroot()
+        controllers = [
+            element
+            for element in root.iter()
+            if local_name(element.tag) == "Controller"
+        ]
+        self.assertEqual(
+            [controller.get("name") for controller in controllers],
+            ["RosRouteController"],
+        )
+        controller_actions = [
+            element
+            for element in root.iter()
+            if local_name(element.tag) == "ControllerAction"
+        ]
+        self.assertEqual(len(controller_actions), 1)
+        self.assertTrue(
+            any(
+                local_name(element.tag) == "AssignControllerAction"
+                for element in controller_actions[0].iter()
+            )
+        )
+
+    def test_import_removes_actor_object_controller_catalog_dependency(self):
+        catalog_scenario = self.root / "catalog-controller.xosc"
+        source = SCENARIO.replace(
+            '<FileHeader revMajor="1" revMinor="1"/>',
+            '<FileHeader revMajor="1" revMinor="1"/>'
+            '<CatalogLocations><ControllerCatalog><Directory '
+            'path="./Catalogs/Controllers"/></ControllerCatalog></CatalogLocations>',
+        ).replace(
+            "</Vehicle>\n    </ScenarioObject>",
+            '</Vehicle><ObjectController><CatalogReference '
+            'catalogName="ControllerCatalog" entryName="interactiveDriver"/>'
+            "</ObjectController>\n    </ScenarioObject>",
+            1,
+        )
+        catalog_scenario.write_text(source, encoding="utf-8")
+
+        strict_report = validate_scenario(catalog_scenario, repo_root=self.root)
+        self.assertFalse(strict_report.is_valid)
+        self.assertTrue(
+            any("ObjectController" in error for error in strict_report.errors)
+        )
+
+        result = import_scenario(
+            catalog_scenario,
+            output_root=self.output,
+            name="catalog-controller",
+            repo_root=self.root,
+        )
+        root = ET.parse(result.scenario_file).getroot()
+        self.assertFalse(any(local_name(item.tag) == "ObjectController" for item in root.iter()))
+        self.assertFalse(any(local_name(item.tag) == "CatalogReference" for item in root.iter()))
+        catalog_locations = next(
+            item for item in root.iter() if local_name(item.tag) == "CatalogLocations"
+        )
+        self.assertEqual(len(list(catalog_locations)), 0)
+        self.assertTrue(any("Removed 1" in action for action in result.actions))
+
+    def test_import_rejects_other_external_catalog_references(self):
+        catalog_scenario = self.root / "external-catalog.xosc"
+        catalog_scenario.write_text(
+            SCENARIO.replace(
+                "</Vehicle>\n    </ScenarioObject>",
+                '</Vehicle><CatalogReference catalogName="VehicleCatalog" '
+                'entryName="externalVehicle"/>\n    </ScenarioObject>',
+                1,
+            ),
+            encoding="utf-8",
+        )
+
+        report = validate_scenario(
+            catalog_scenario,
+            repo_root=self.root,
+            allow_repair=True,
+        )
+
+        self.assertFalse(report.is_valid)
+        self.assertTrue(
+            any(
+                "unsupported external CatalogReference" in error
+                for error in report.errors
+            )
+        )
+
+    def test_referenced_opendrive_requires_explicit_upload(self):
+        missing = self.root / "missing.xosc"
+        missing.write_text(
+            SCENARIO.replace('filepath="campus"', 'filepath="custom.xodr"'),
+            encoding="utf-8",
+        )
+        (self.root / "custom.xodr").write_text("<OpenDRIVE/>", encoding="utf-8")
+        (self.root / "custom.osm").write_text("<osm/>", encoding="utf-8")
+        report = validate_scenario(missing, repo_root=self.root, allow_repair=True)
+        self.assertFalse(report.is_valid)
+        self.assertIn("must be explicitly uploaded", report.errors[0])
+
+    def test_custom_map_is_resolved_only_relative_to_scenario(self):
+        upload_directory = self.root / "uploads"
+        upload_directory.mkdir()
+        uploaded_scenario = upload_directory / "source.xosc"
+        uploaded_scenario.write_text(
+            SCENARIO.replace('filepath="campus"', 'filepath="scenario.xodr"'),
+            encoding="utf-8",
+        )
+        (self.root / "scenario.xodr").write_text("<OpenDRIVE/>", encoding="utf-8")
+        (self.root / "scenario.osm").write_text("<osm/>", encoding="utf-8")
+
+        report = validate_scenario(
+            uploaded_scenario,
+            repo_root=self.root,
+            allow_repair=True,
+        )
+
+        self.assertFalse(report.is_valid)
+        self.assertTrue(any("must be explicitly uploaded" in error for error in report.errors))
+
+    def test_import_colocates_explicit_custom_map_files(self):
+        bundle = self.root / "bundle"
+        bundle.mkdir()
+        map_sources = self.root / "map-sources"
+        map_sources.mkdir()
+        bundled_scenario = bundle / "source.xosc"
+        bundled_scenario.write_text(
+            SCENARIO.replace('filepath="campus"', 'filepath="custom.xodr"'),
+            encoding="utf-8",
+        )
+        (map_sources / "custom.xodr").write_text("<OpenDRIVE/>", encoding="utf-8")
+        (map_sources / "custom.osm").write_text("<osm/>", encoding="utf-8")
+
+        result = import_scenario(
+            bundled_scenario,
+            output_root=self.output,
+            name="bundle",
+            opendrive=map_sources / "custom.xodr",
+            lanelet=map_sources / "custom.osm",
+            repo_root=self.root,
+        )
+
+        self.assertEqual(result.scenario_file.parent, result.directory)
+        self.assertEqual(result.map_resolution.opendrive.parent, result.directory)
+        self.assertEqual(result.map_resolution.lanelet.parent, result.directory)
+        self.assertTrue((result.directory / "bundle.xosc").is_file())
+        self.assertTrue((result.directory / "custom.xodr").is_file())
+        self.assertTrue((result.directory / "custom.osm").is_file())
+
+    def test_custom_map_files_must_share_scenario_directory(self):
+        map_directory = self.root / "maps"
+        map_directory.mkdir()
+        opendrive = map_directory / "custom.xodr"
+        lanelet = map_directory / "custom.osm"
+        opendrive.write_text("<OpenDRIVE/>", encoding="utf-8")
+        lanelet.write_text("<osm/>", encoding="utf-8")
+
+        report = validate_scenario(
+            self.scenario,
+            opendrive=opendrive,
+            lanelet=lanelet,
+            expected_opendrive=opendrive,
+            expected_lanelet=lanelet,
+            repo_root=self.root,
+            allow_repair=True,
+        )
+
+        self.assertFalse(report.is_valid)
+        self.assertTrue(any("same directory" in error for error in report.errors))
+
+        local_opendrive = self.root / "custom.xodr"
+        local_opendrive.write_text("<OpenDRIVE/>", encoding="utf-8")
+        lanelet_report = validate_scenario(
+            self.scenario,
+            opendrive=local_opendrive,
+            lanelet=lanelet,
+            expected_opendrive=local_opendrive,
+            expected_lanelet=lanelet,
+            repo_root=self.root,
+            allow_repair=True,
+        )
+        self.assertFalse(lanelet_report.is_valid)
+        self.assertTrue(
+            any(
+                "CUSTOM_LANELET must be in the same directory" in error
+                for error in lanelet_report.errors
+            )
+        )
+
+    def test_runtime_logic_file_must_match_opendrive_name_without_directory(self):
+        opendrive = self.root / "custom.xodr"
+        lanelet = self.root / "custom.osm"
+        opendrive.write_text("<OpenDRIVE/>", encoding="utf-8")
+        lanelet.write_text("<osm/>", encoding="utf-8")
+
+        report = validate_scenario(
+            self.scenario,
+            opendrive=opendrive,
+            lanelet=lanelet,
+            expected_opendrive=opendrive,
+            expected_lanelet=lanelet,
+            repo_root=self.root,
+            allow_repair=True,
+        )
+
+        self.assertFalse(report.is_valid)
+        self.assertTrue(
+            any(
+                "same directory as the OpenSCENARIO file" in error
+                for error in report.errors
+            )
+        )
+
+    def test_runtime_validation_resolves_environment_paths(self):
+        opendrive = self.root / "custom.xodr"
+        lanelet = self.root / "custom.osm"
+        opendrive.write_text("<OpenDRIVE/>", encoding="utf-8")
+        lanelet.write_text("<osm/>", encoding="utf-8")
+        scenario_root = self.root / "carla-simulation/scenarios"
+        result = import_scenario(
+            self.scenario,
+            output_root=scenario_root / "custom-imports",
+            name="runtime",
+            opendrive=opendrive,
+            lanelet=lanelet,
+            repo_root=self.root,
+        )
+        prefix = "carla-simulation/scenarios/custom-imports/runtime"
+        environment = {
+            "SCENARIO_FILE": f"{prefix}/runtime.xosc",
+            "MAP": "",
+            "CUSTOM_OPENDRIVE": f"{prefix}/custom.xodr",
+            "CUSTOM_LANELET": f"{prefix}/custom.osm",
+        }
+
+        duplicate = scenario_root / "custom-imports/duplicate"
+        duplicate.mkdir()
+        (duplicate / "duplicate.xosc").write_text(
+            SCENARIO.replace('filepath="campus"', 'filepath="custom.xodr"'),
+            encoding="utf-8",
+        )
+        (duplicate / "custom.xodr").write_text("<OpenDRIVE/>", encoding="utf-8")
+        (duplicate / "custom.osm").write_text("<osm/>", encoding="utf-8")
+
+        automated = validate_runtime(result.scenario_file, environment)
+        manual = validate_runtime(scenario_root, environment)
+        wrong_bundle = validate_runtime(duplicate / "duplicate.xosc", environment)
+
+        self.assertTrue(automated["valid"])
+        self.assertTrue(manual["valid"])
+        self.assertEqual(manual["checked"], 1)
+        self.assertFalse(wrong_bundle["valid"])
+        self.assertTrue(
+            any("same directory" in error for error in wrong_bundle["errors"])
+        )
+        self.assertEqual(Path(automated["scenario"]), result.scenario_file)
+
+        with self.assertRaisesRegex(ScenarioCheckerError, "does not exist"):
+            validate_runtime(scenario_root / "missing.xosc", environment)
+
+    def test_import_converts_openscenario_1_2_to_1_1(self):
+        scenario_1_2 = self.root / "source-1.2.xosc"
+        scenario_1_2.write_text(
+            SCENARIO.replace('revMinor="1"', 'revMinor="2"')
+            .replace(
+                "  <RoadNetwork>",
+                "  <VariableDeclarations><VariableDeclaration name=\"state\" variableType=\"string\" value=\"idle\"/></VariableDeclarations>\n"
+                "  <RoadNetwork>",
+            )
+            .replace(
+                '<Event name="other_route">',
+                '<Event name="other_route" priority="override">',
+            )
+            .replace(
+                "      <StartTrigger/>",
+                '      <RelativeDistanceCondition relativeDistanceType="cartesianDistance"/>\n'
+                "      <StartTrigger/>",
+            ),
+            encoding="utf-8",
+        )
+
+        strict_report = validate_scenario(scenario_1_2, repo_root=self.root)
+        self.assertFalse(strict_report.is_valid)
+        self.assertTrue(any("OpenSCENARIO 1.2" in error for error in strict_report.errors))
+
+        result = import_scenario(
+            scenario_1_2,
+            output_root=self.output,
+            name="converted",
+            repo_root=self.root,
+        )
+        root = ET.parse(result.scenario_file).getroot()
+        header = next(element for element in root if local_name(element.tag) == "FileHeader")
+        self.assertEqual((header.get("revMajor"), header.get("revMinor")), ("1", "1"))
+        self.assertFalse(
+            any(local_name(element.tag) == "VariableDeclarations" for element in root)
+        )
+        event = next(
+            element
+            for element in root.iter()
+            if local_name(element.tag) == "Event" and element.get("name") == "other_route"
+        )
+        self.assertEqual(event.get("priority"), "overwrite")
+        distance = next(
+            element
+            for element in root.iter()
+            if local_name(element.tag) == "RelativeDistanceCondition"
+        )
+        self.assertEqual(distance.get("relativeDistanceType"), "euclidianDistance")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/scenario-checker/test_scenario_checker.py
+++ b/utils/scenario-checker/test_scenario_checker.py
@@ -187,6 +187,75 @@ class ScenarioCheckerTests(unittest.TestCase):
             )
         )
 
+    def test_import_replaces_controllers_across_ego_blocks_and_story(self):
+        imported = import_scenario(self.scenario, output_root=self.output)
+        tree = ET.parse(imported.scenario_file)
+        root = tree.getroot()
+        actions = root.find("./Storyboard/Init/Actions")
+        controller_xml = (
+            '<PrivateAction><ControllerAction><AssignControllerAction>'
+            '<Controller name="OldController"><Properties>'
+            '<Property name="module" value="old.py"/>'
+            '</Properties></Controller></AssignControllerAction>'
+            '</ControllerAction></PrivateAction>'
+        )
+        extra = ET.SubElement(actions, "Private", entityRef="ego_vehicle")
+        extra.append(ET.fromstring(controller_xml))
+        other = ET.SubElement(actions, "Private", entityRef="car_2")
+        other.append(ET.fromstring(controller_xml))
+        event = root.find(".//ManeuverGroup[@name='ego']//Event")
+        story_action = ET.SubElement(event, "Action", name="switch_controller")
+        story_action.append(ET.fromstring(controller_xml))
+        maneuver = root.find(".//ManeuverGroup[@name='ego']/Maneuver")
+        controller_event = ET.SubElement(maneuver, "Event", name="controller_only")
+        ET.SubElement(controller_event, "Action", name="switch").append(
+            ET.fromstring(controller_xml)
+        )
+        tree.write(imported.scenario_file)
+        source = imported.scenario_file.read_bytes()
+        report = validate_scenario(imported.scenario_file)
+        self.assertFalse(report.is_valid)
+        self.assertTrue(any("controller setup" in error for error in report.errors))
+
+        result = import_scenario(imported.scenario_file, output_root=self.output)
+        output = ET.parse(result.scenario_file).getroot()
+        ego_controllers = output.findall(
+            "./Storyboard/Init/Actions/Private[@entityRef='ego_vehicle']//Controller"
+        )
+        self.assertEqual([c.get("name") for c in ego_controllers], ["RosRouteController"])
+        self.assertEqual(
+            ego_controllers[0].find("./Properties/Property[@name='module']").get("value"),
+            "ros_vehicle_control_route_action.py",
+        )
+        self.assertFalse(output.findall(".//ManeuverGroup[@name='ego']//ControllerAction"))
+        self.assertIsNone(output.find(".//Event[@name='controller_only']"))
+        self.assertIsNotNone(output.find(".//Event[@name='ego_route']/Action"))
+        self.assertEqual(len(output.findall(
+            "./Storyboard/Init/Actions/Private[@entityRef='car_2']//Controller"
+        )), 1)
+        self.assertTrue(validate_scenario(result.scenario_file).is_valid)
+        self.assertEqual(imported.scenario_file.read_bytes(), source)
+
+        # A shared action must not silently change the other actor's controller.
+        actors = root.find(".//ManeuverGroup[@name='ego']/Actors")
+        ET.SubElement(actors, "EntityRef", entityRef="car_2")
+        tree.write(imported.scenario_file)
+        with self.assertRaisesRegex(ScenarioCheckerError, "shared with other actors"):
+            import_scenario(imported.scenario_file, output_root=self.output)
+
+    def test_validation_accepts_single_ros_controller_in_later_init_block(self):
+        imported = import_scenario(self.scenario, output_root=self.output)
+        tree = ET.parse(imported.scenario_file)
+        actions = tree.getroot().find("./Storyboard/Init/Actions")
+        ego = actions.find("Private[@entityRef='ego_vehicle']")
+        later = ET.SubElement(actions, "Private", entityRef="ego_vehicle")
+        for action in list(ego):
+            if action.find("ControllerAction") is not None:
+                ego.remove(action)
+                later.append(action)
+        tree.write(imported.scenario_file)
+        self.assertTrue(validate_scenario(imported.scenario_file).is_valid)
+
     def test_import_removes_actor_object_controller_catalog_dependency(self):
         catalog_scenario = self.root / "catalog-controller.xosc"
         source = SCENARIO.replace(


### PR DESCRIPTION
Adds validation and import tooling for custom OpenSCENARIO/OpenDRIVE/Lanelet2 bundles:

- Normalizes ego/controller setup, OSC version, weather, teleport Z, RTS mode, stop triggers and criteria
- Stores custom scenarios and maps together under scenarios/custom-imports
- Keeps scenario and map selections synchronized in the GUI
- Adds runtime validation to prevent incompatible scenario/map combinations
